### PR TITLE
Decouple SOLVCON repository for devenv building

### DIFF
--- a/build-pybind11-in-conda.sh
+++ b/build-pybind11-in-conda.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# build and install pybind11 for cmake.
+
+conda_root=$(which conda)
+
+if [ -z "$conda_root" ] ; then
+  echo "conda not found, exit"
+  exit 1
+fi
+
+conda_root=$(cd $(dirname "${conda_root}")/.. && pwd)
+echo "conda_root: ${conda_root}"
+
+mkdir -p $conda_root/tmp
+cd $conda_root/tmp
+curl -sSL -o pybind11.zip https://github.com/pybind/pybind11/archive/master.zip
+rm -rf pybind11-master
+unzip pybind11.zip
+cd pybind11-master
+mkdir -p build
+cd build
+cmake -DPYBIND11_TEST=OFF -DPYTHON_EXECUTABLE:FILEPATH=`which python` -DCMAKE_INSTALL_PREFIX=${conda_root} ..
+make install

--- a/conda.sh
+++ b/conda.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+conda install -y \
+  python=3.6 \
+  cmake setuptools pip sphinx ipython jupyter \
+  cython numpy hdf4 netcdf4 nose pytest paramiko boto graphviz
+lret=$?; if [[ $lret != 0 ]] ; then exit $lret; fi
+conda install -y -c https://conda.anaconda.org/yungyuc \
+  gmsh scotch
+lret=$?; if [[ $lret != 0 ]] ; then exit $lret; fi
+pip install pybind11 pythreejs
+lret=$?; if [[ $lret != 0 ]] ; then exit $lret; fi

--- a/devenv-cli.sh
+++ b/devenv-cli.sh
@@ -1,4 +1,5 @@
-SOLVCON_WORKING_ROOT=${HOME}/solvcon/devenv
+# SCDE: SOLVCON Dev Env
+SCDE_SRC=${HOME}/solvcon/devenv
 
-mkdir -p ${SOLVCON_WORKING_ROOT}
-source ${SOLVCON_WORKING_ROOT}/prepare-solvcon-dev.sh
+mkdir -p ${SCDE_SRC}
+source ${SCDE_SRC}/prepare-solvcon-dev.sh

--- a/prepare-solvcon-dev.sh
+++ b/prepare-solvcon-dev.sh
@@ -9,14 +9,12 @@ set -x
 SOLVCON_PROJECT=${1:-${HOME}/solvcon}
 SCSRC="${SOLVCON_PROJECT}/solvcon"
 SCSRC_WORKING="${SOLVCON_PROJECT}/solvcon-working"
+SCDE_SRC=${SOLVCON_DEVENV_SRC:-${SOLVCON_PROJECT}/devenv}
 MINICONDA_DIR="${SCSRC_WORKING}/miniconda"
 
 export PATH="${SCSRC}:${MINICONDA_DIR}/bin:${PATH}"
 
 mkdir -p ${SCSRC_WORKING}
-
-# fetch SOLVCON source
-git clone https://github.com/solvcon/solvcon.git ${SCSRC}
 
 # prepare miniconda
 # please note contrib/conda.sh will use python 3.6 if you want to install
@@ -45,11 +43,14 @@ conda update -q conda
 conda create -p ${SCSRC_WORKING}/venv-conda --no-default-packages -y python
 source activate ${SCSRC_WORKING}/venv-conda
 
+# prepare all packages to build SOLVCON
+${SCDE_SRC}/conda.sh
+${SCDE_SRC}/build-pybind11-in-conda.sh
+
 set +x
 
-# prepare all packages to build SOLVCON
-${SCSRC}/contrib/conda.sh
-${SCSRC}/contrib/build-pybind11-in-conda.sh
+# fetch SOLVCON source
+git clone https://github.com/solvcon/solvcon.git ${SCSRC}
 
 pushd ${SCSRC}
 # make libmarch.so and SOLVCON


### PR DESCRIPTION
By copying the files used to build devenv from SOLVCON repository, we
could build devenv without depending on SOLVCON.

Issue #6