### PR TITLE
Err out when DEVENVROOT is not set

### DIFF
--- a/bin/devenv
+++ b/bin/devenv
@@ -3,6 +3,10 @@
   set -x
 }
 
+if [ -z "${DEVENVROOT}" ] ; then
+  export DEVENVROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fi
+
 . ${DEVENVROOT}/scripts/func.d/bash_utils
 
 cmd=$1

--- a/bin/devenv
+++ b/bin/devenv
@@ -4,7 +4,8 @@
 }
 
 if [ -z "${DEVENVROOT}" ] ; then
-  export DEVENVROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+  echo "Environment variable DEVENVROOT not found"
+  exit 1
 fi
 
 . ${DEVENVROOT}/scripts/func.d/bash_utils


### PR DESCRIPTION
``devenv`` crashes when ``$DEVENVROOT`` is not set before running the command.