### PR TITLE
feat: add devenv command autocomplete

### DIFF
--- a/scripts/func.d/bash_utils
+++ b/scripts/func.d/bash_utils
@@ -9,4 +9,20 @@ display() {
   fi
 }
 
+get_list() {
+  local dir=""
+  case $1 in
+    flavor)
+      dir="${DEVENVROOT}/flavors"
+      ;;
+    build)
+      dir="${DEVENVROOT}/scripts/build.d"
+      ;;
+    cmd)
+      dir="${DEVENVROOT}/scripts/cmd.d"
+      ;;
+  esac
+  echo $(${LS_PATH} -1 ${dir} 2>/dev/null)
+}
+
 # vim: set et nu nobomb fenc=utf8 ft=sh ff=unix sw=2 ts=2:

--- a/scripts/init
+++ b/scripts/init
@@ -32,4 +32,35 @@ devenv() {
   fi
 }
 
+_devenv() {
+  . ${DEVENVROOT}/scripts/func.d/bash_utils
+
+  local cur prev opts base
+	COMPREPLY=()
+	cur="${COMP_WORDS[COMP_CWORD]}"
+	base="${COMP_WORDS[0]}"
+	cmd="${COMP_WORDS[1]}"
+
+  case "${cmd}" in
+    use|del)
+      [[ $COMP_CWORD > 2 ]] && return 1
+      COMPREPLY=( $(compgen -W "$(get_list flavor)" -- ${cur}) )
+			return 0
+      ;;
+    build)
+      [[ $COMP_CWORD > 2 ]] && return 1
+      COMPREPLY=( $(compgen -W "$(get_list build)" -- ${cur}) )
+			return 0
+      ;;
+    *)
+      [[ $COMP_CWORD > 1 ]] && return 1
+      cmds=$(get_list cmd)
+      cmds+=" use off"
+      COMPREPLY=($(compgen -W "${cmds}" -- ${cur}))
+      return 0
+      ;;
+  esac
+}
+complete -F _devenv devenv
+
 # vim: set et nu nobomb fenc=utf8 ft=bash ff=unix sw=2 ts=2:

--- a/scripts/init
+++ b/scripts/init
@@ -36,21 +36,21 @@ _devenv() {
   . ${DEVENVROOT}/scripts/func.d/bash_utils
 
   local cur prev opts base
-	COMPREPLY=()
-	cur="${COMP_WORDS[COMP_CWORD]}"
-	base="${COMP_WORDS[0]}"
-	cmd="${COMP_WORDS[1]}"
+  COMPREPLY=()
+  cur="${COMP_WORDS[COMP_CWORD]}"
+  base="${COMP_WORDS[0]}"
+  cmd="${COMP_WORDS[1]}"
 
   case "${cmd}" in
     use|del)
       [[ $COMP_CWORD > 2 ]] && return 1
       COMPREPLY=( $(compgen -W "$(get_list flavor)" -- ${cur}) )
-			return 0
+      return 0
       ;;
     build)
       [[ $COMP_CWORD > 2 ]] && return 1
       COMPREPLY=( $(compgen -W "$(get_list build)" -- ${cur}) )
-			return 0
+      return 0
       ;;
     *)
       [[ $COMP_CWORD > 1 ]] && return 1


### PR DESCRIPTION
As title, I added devenv command autocomplete, 
devenv can autocomplete it own command, `add` , `build`, `del`, `off`, `use`
and the following command also have autocomplete:

`use`, `del` will show the folders contained by `flavor`
`build` will show build scripts contain by `build.d`, if `build.d` not exist will show nothing 