### PR TITLE
Integrate SOLVCON and gmsh build

### DIFF
--- a/applications/solvcon/conda.sh
+++ b/applications/solvcon/conda.sh
@@ -4,8 +4,7 @@ conda install -y \
   cmake setuptools pip sphinx ipython jupyter \
   cython numpy hdf4 netcdf4 nose pytest paramiko boto graphviz
 lret=$?; if [[ $lret != 0 ]] ; then exit $lret; fi
-conda install -y -c https://conda.anaconda.org/yungyuc \
-  gmsh scotch
+conda install -y -c https://conda.anaconda.org/yungyuc scotch
 lret=$?; if [[ $lret != 0 ]] ; then exit $lret; fi
 pip install pybind11 pythreejs
 lret=$?; if [[ $lret != 0 ]] ; then exit $lret; fi

--- a/applications/solvcon/prepare-solvcon-dev.sh
+++ b/applications/solvcon/prepare-solvcon-dev.sh
@@ -44,6 +44,10 @@ conda create -p ${SCSRC_WORKING}/venv-conda --no-default-packages -y python
 source activate ${SCSRC_WORKING}/venv-conda
 
 # prepare all packages to build SOLVCON
+source ${DEVENV_TOOL}/scripts/init
+devenv add ${DEVENV_FLAVOR}
+devenv use ${DEVENV_FLAVOR}
+VERSION=gmsh_3_0_6 devenv build gmsh
 ${SCDE_SRC}/conda.sh
 ${SCDE_SRC}/build-pybind11-in-conda.sh
 

--- a/bin/build-application-solvcon-devenv.sh
+++ b/bin/build-application-solvcon-devenv.sh
@@ -1,5 +1,6 @@
 # SCDE: SOLVCON Dev Env
-SCDE_SRC=${HOME}/solvcon/devenv/applications/solvcon
+DEVENV_TOOL=${HOME}/solvcon/devenv
+DEVENV_FLAVOR="solvcon-devenv"
+SCDE_SRC=${DEVENV_TOOL}/applications/solvcon
 
-mkdir -p ${SCDE_SRC}
 source ${SCDE_SRC}/prepare-solvcon-dev.sh


### PR DESCRIPTION
We have introduced gmsh as one of our build component in this commit https://github.com/solvcon/devenv/pull/19 . This pull request is a follow-up task to integrate the usage of gmsh build component of `devenv` and SOLVCON.

# How to Test This Pull Request
1. `source scripts/init`
2. `devnev add solvcon-01`
3. `devenv use solvcon-01`
4. `bin/build-application-solvcon-devenv.sh`


# Expected Result
SOLVCON could pass its unittest with the environment built by devenv.
