### PR TITLE
Add build-essential debian package

### DIFF
--- a/scripts/env.d/devenv_impl
+++ b/scripts/env.d/devenv_impl
@@ -17,6 +17,14 @@ nameremove() {
   eval "export $1=$(echo -n ${!1} | awk -v RS=: -v ORS=: -v var="$2" '$0 != var' | sed 's/:*$//')"
 }
 
+# Necessary evil
+if [[ -f "/etc/os-release" ]]; then
+    str=$(grep -o 'ubuntu' /etc/os-release 2> /dev/null | head -1)
+    if [[ ${str} == "ubuntu" ]]; then
+      sudo apt install build-essential -y
+    fi
+fi
+
 case "$(uname)" in
   Darwin)
     lib_path=DYLD_FALLBACK_LIBRARY_PATH


### PR DESCRIPTION
When build openssl, the following error come out.
```
done; log file: /home/swss/devenv/flavors/demo/src/openssl-master/configure.log
run command: make -j 6
/home/swss/devenv/scripts/func.d/build_utils: line 3: make: command not found
```
A necessary evil for make command.