### PR TITLE
add DEVENVFLAVORROOT to support customized flavor dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ By using the following command to setup all necessary environment variables:
 source scripts/init
 ```
 
+## Advanced Configuration
+
+* Customized flavors directory path: You may define the `DEVENVFLAVORROOT`
+environment variable to point to the flavors root path where you want.
+
 
 ## Usage
 

--- a/scripts/build.d/bzip2
+++ b/scripts/build.d/bzip2
@@ -4,9 +4,9 @@ set -e
 
 pkgname=bzip2
 
-git clone git://sourceware.org/git/bzip2.git ${DEVENVROOT}/flavors/${DEVENVFLAVOR}/src/${pkgname}
+git clone git://sourceware.org/git/bzip2.git ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src/${pkgname}
 
-pushd ${DEVENVROOT}/flavors/${DEVENVFLAVOR}/src/${pkgname} > /dev/null
+pushd ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src/${pkgname} > /dev/null
 
   INSTALL_PREFIX=${DEVENVPREFIX}
   buildcmd make.log make install PREFIX=${INSTALL_PREFIX} -j ${NP}

--- a/scripts/build.d/cmake
+++ b/scripts/build.d/cmake
@@ -12,7 +12,7 @@ syncgit https://github.com/Kitware ${pkgname} ${pkgbranch}
 cfgcmd=("./configure")
 cfgcmd+=("--prefix=${DEVENVPREFIX}")
 
-pushd ${DEVENVROOT}/flavors/${DEVENVFLAVOR}/src/${pkgfull} > /dev/null
+pushd ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src/${pkgfull} > /dev/null
 
   buildcmd configure.log "${cfgcmd[@]}"
   buildcmd make.log make -j ${NP}

--- a/scripts/build.d/cython
+++ b/scripts/build.d/cython
@@ -9,7 +9,7 @@ pkgfull=${pkgname}-${pkgbranch}
 
 syncgit https://github.com/cython ${pkgname} ${pkgbranch}
 
-pushd ${DEVENVROOT}/flavors/${DEVENVFLAVOR}/src/${pkgfull} > /dev/null
+pushd ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src/${pkgfull} > /dev/null
 
   PYTHON=${DEVENVPREFIX}/bin/python3
 

--- a/scripts/build.d/gmsh
+++ b/scripts/build.d/gmsh
@@ -8,7 +8,7 @@ pkgfull=$pkgname-$pkgbranch
 
 syncgit https://gitlab.onelab.info/gmsh/ ${pkgname} ${pkgbranch}
 
-pushd ${DEVENVROOT}/flavors/${DEVENVFLAVOR}/src/${pkgfull} > /dev/null
+pushd ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src/${pkgfull} > /dev/null
 
   mkdir -p build
 

--- a/scripts/build.d/hdf
+++ b/scripts/build.d/hdf
@@ -9,7 +9,7 @@ pkgfull=${pkgname}-${pkgbranch}
 # unpack (clone / pull)
 syncgit https://github.com/HDFGroup ${pkgname} ${pkgbranch}
 
-pushd ${DEVENVROOT}/flavors/${DEVENVFLAVOR}/src/${pkgfull} > /dev/null
+pushd ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src/${pkgfull} > /dev/null
 
   mkdir -p build
   cd build

--- a/scripts/build.d/modmesh
+++ b/scripts/build.d/modmesh
@@ -15,7 +15,7 @@ PYTHON=${DEVENVPREFIX}/bin/python3
 
 syncgit https://github.com/solvcon ${pkgname} ${pkgbranch}
 
-pushd ${DEVENVROOT}/flavors/${DEVENVFLAVOR}/src/${pkgfull} > /dev/null
+pushd ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src/${pkgfull} > /dev/null
 
   if [ -e build ]; then
     rm -rf build
@@ -23,7 +23,7 @@ pushd ${DEVENVROOT}/flavors/${DEVENVFLAVOR}/src/${pkgfull} > /dev/null
 
   mkdir -p build
 
-  pushd ${DEVENVROOT}/flavors/${DEVENVFLAVOR}/src/${pkgfull}/build > /dev/null
+  pushd ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src/${pkgfull}/build > /dev/null
 
     cmakecmd=("cmake")
     cmakecmd+=("-DCMAKE_INSTALL_PREFIX=${DEVENVPREFIX}")

--- a/scripts/build.d/netcdf
+++ b/scripts/build.d/netcdf
@@ -9,7 +9,7 @@ pkgfull=${pkgname}-${pkgbranch}
 # unpack (clone / pull)
 syncgit https://github.com/Unidata ${pkgname} ${pkgbranch}
 
-pushd ${DEVENVROOT}/flavors/${DEVENVFLAVOR}/src/${pkgfull} > /dev/null
+pushd ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src/${pkgfull} > /dev/null
 
   mkdir -p build
   cd build

--- a/scripts/build.d/numpy
+++ b/scripts/build.d/numpy
@@ -9,7 +9,7 @@ pkgfull=${pkgname}-${pkgbranch}
 # unpack (clone / pull)
 syncgit https://github.com/numpy ${pkgname} ${pkgbranch}
 
-pushd ${DEVENVROOT}/flavors/${DEVENVFLAVOR}/src/${pkgfull} > /dev/null
+pushd ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src/${pkgfull} > /dev/null
 
 # prepare files for building.
 if [ ! -e ${DEVENVPREFIX}/bin/python3 ]; then

--- a/scripts/build.d/openblas
+++ b/scripts/build.d/openblas
@@ -9,7 +9,7 @@ pkgfull=${pkgname}-${pkgbranch}
 # unpack (clone / pull)
 syncgit https://github.com/xianyi ${pkgname} ${pkgbranch}
 
-pushd ${DEVENVROOT}/flavors/${DEVENVFLAVOR}/src/${pkgfull} > /dev/null
+pushd ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src/${pkgfull} > /dev/null
 
   mkdir -p build
   cd build

--- a/scripts/build.d/openssl
+++ b/scripts/build.d/openssl
@@ -8,7 +8,7 @@ pkgfull=${pkgname}-${pkgbranch}
 
 syncgit https://github.com/openssl ${pkgname} ${pkgbranch}
 
-pushd ${DEVENVROOT}/flavors/${DEVENVFLAVOR}/src/${pkgfull} > /dev/null
+pushd ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src/${pkgfull} > /dev/null
 
   cfgcmd=("./config")
   cfgcmd+=("--prefix=${DEVENVPREFIX}")

--- a/scripts/build.d/pybind11
+++ b/scripts/build.d/pybind11
@@ -30,15 +30,15 @@ elif [[ $DEVENVFLAVOR == dbg* ]] ; then
   cmakecmd+=("-DCMAKE_BUILD_TYPE=Debug")
 fi
 
-mkdir -p ${DEVENVROOT}/flavors/${DEVENVFLAVOR}/src/${pkgfull}/build
+mkdir -p ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src/${pkgfull}/build
 
-pushd ${DEVENVROOT}/flavors/${DEVENVFLAVOR}/src/${pkgfull}/build > /dev/null
+pushd ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src/${pkgfull}/build > /dev/null
 
   buildcmd cmake.log "${cmakecmd[@]}" ..
   buildcmd make.log make -j $NP
   buildcmd install.log make install
 
-  pushd ${DEVENVROOT}/flavors/${DEVENVFLAVOR}/src/${pkgfull} > /dev/null
+  pushd ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src/${pkgfull} > /dev/null
     buildcmd build/setup.log $PYTHON setup.py install
   popd > /dev/null
 

--- a/scripts/build.d/python
+++ b/scripts/build.d/python
@@ -8,7 +8,7 @@ pkgfull=${pkgname}-${pkgbranch}
 
 syncgit https://github.com/python ${pkgname} ${pkgbranch}
 
-pushd ${DEVENVROOT}/flavors/${DEVENVFLAVOR}/src/${pkgfull} > /dev/null
+pushd ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src/${pkgfull} > /dev/null
 
   # build
   PREFIX=${DEVENVPREFIX}

--- a/scripts/build.d/scotch
+++ b/scripts/build.d/scotch
@@ -12,8 +12,8 @@ if [ -z "${SYNCGIT}" ]; then
   # download tarball
   download_md5 $pkgfn $pkgurl 5b851c3dc0a54185aecb44980ed3a334
 
-  mkdir -p ${DEVENVROOT}/flavors/${DEVENVFLAVOR}/src
-  cd ${DEVENVROOT}/flavors/${DEVENVFLAVOR}/src
+  mkdir -p ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src
+  cd ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src
   tar xf ${DEVENVDLROOT}/$pkgfn
 else
   pkgname=scotch
@@ -24,8 +24,8 @@ else
   syncgit https://gitlab.inria.fr/scotch ${pkgname} ${pkgbranch}
 fi
 
-pushd ${DEVENVROOT}/flavors/${DEVENVFLAVOR}/src/${pkgfull} > /dev/null
-  pushd ${DEVENVROOT}/flavors/${DEVENVFLAVOR}/src/${pkgfull}/src
+pushd ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src/${pkgfull} > /dev/null
+  pushd ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src/${pkgfull}/src
     # build.
     rm -f Makefile.inc
     echo "prefix = $DEVENVPREFIX" > Makefile.inc

--- a/scripts/build.d/xz
+++ b/scripts/build.d/xz
@@ -8,7 +8,7 @@ pkgfull=$pkgname-$pkgbranch
 
 syncgit https://github.com/xz-mirror/ ${pkgname} ${pkgbranch}
 
-pushd ${DEVENVROOT}/flavors/${DEVENVFLAVOR}/src/${pkgfull} > /dev/null
+pushd ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src/${pkgfull} > /dev/null
 
   mkdir -p build
 

--- a/scripts/build.d/zlib
+++ b/scripts/build.d/zlib
@@ -8,7 +8,7 @@ pkgfull=${pkgname}-${pkgbranch}
 
 syncgit https://github.com/madler ${pkgname} ${pkgbranch}
 
-pushd ${DEVENVROOT}/flavors/${DEVENVFLAVOR}/src/${pkgfull} > /dev/null
+pushd ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src/${pkgfull} > /dev/null
 
   # build.
   buildcmd configure.log ./configure --prefix=${DEVENVPREFIX}

--- a/scripts/cmd.d/add
+++ b/scripts/cmd.d/add
@@ -1,7 +1,7 @@
 . ${DEVENVROOT}/scripts/func.d/bash_utils
 
-if [ ! -d "${DEVENVROOT}/flavors/$1" ]; then
-  mkdir -p ${DEVENVROOT}/flavors/$1
+if [ ! -d "${DEVENVFLAVORROOT}/$1" ]; then
+  mkdir -p ${DEVENVFLAVORROOT}/$1
   display "create '${1}' dev environment."
 elif [ -z $1 ]; then
   display -e "must need an argument!!"

--- a/scripts/cmd.d/del
+++ b/scripts/cmd.d/del
@@ -3,7 +3,7 @@
 if [ -z $1 ]; then
   display -e "must need an argument!!"
 else
-  rm -rf ${DEVENVROOT}/flavors/$1
+  rm -rf ${DEVENVFLAVORROOT}/$1
   display "removing '$1' dev environment"
 fi
 

--- a/scripts/env.d/devenv_impl
+++ b/scripts/env.d/devenv_impl
@@ -26,12 +26,12 @@ case "$(uname)" in
     ;;
 esac
 
-eval "$1 PATH ${DEVENVROOT}/flavors/$2/usr/bin"
-eval "$1 ${lib_path} ${DEVENVROOT}/flavors/$2/usr/lib"
+eval "$1 PATH ${DEVENVFLAVORROOT}/$2/usr/bin"
+eval "$1 ${lib_path} ${DEVENVFLAVORROOT}/$2/usr/lib"
 
 if [[ "$1" == namemunge ]]; then
   export DEVENVFLAVOR=$2
-  export DEVENVPREFIX=${DEVENVROOT}/flavors/${DEVENVFLAVOR}/usr
+  export DEVENVPREFIX=${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/usr
 elif [[ "$1" == "nameremove" ]]; then
   unset DEVENVFLAVOR
   unset DEVENVPREFIX

--- a/scripts/env.d/vars
+++ b/scripts/env.d/vars
@@ -2,6 +2,7 @@ export DEVENVFLAVOR=""
 export DEVENVPREFIX=""
 export DEVENVPATH_BACKUP="${PATH}"
 export DEVENVDLROOT="${DEVENVROOT}/var/downloaded"
+export DEVENVFLAVORROOT="${DEVENVFLAVORROOT:-$DEVENVROOT/flavors}"
 case "$(uname)" in
   Darwin)
     export DEVENVLIBRARY_PATH_BACKUP="${DYLD_FALLBACK_LIBRARY_PATH}"

--- a/scripts/func.d/bash_utils
+++ b/scripts/func.d/bash_utils
@@ -13,7 +13,7 @@ get_list() {
   local dir=""
   case $1 in
     flavor)
-      dir="${DEVENVROOT}/flavors"
+      dir="${DEVENVFLAVORROOT}"
       ;;
     build)
       dir="${DEVENVROOT}/scripts/build.d"

--- a/scripts/func.d/build_utils
+++ b/scripts/func.d/build_utils
@@ -35,8 +35,8 @@ syncgit () {
   local pkgrepo=${giturl}/${pkgname}.git
 
   # unpack (clone)
-  mkdir -p ${DEVENVROOT}/flavors/${DEVENVFLAVOR}/src
-  pushd ${DEVENVROOT}/flavors/${DEVENVFLAVOR}/src > /dev/null
+  mkdir -p ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src
+  pushd ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src > /dev/null
 
   if [ ! -d ${pkgfull} ] ; then
     git clone -b ${pkgbranch} ${pkgrepo} ${pkgfull}

--- a/scripts/init
+++ b/scripts/init
@@ -8,7 +8,7 @@ devenv() {
   if [[ "$1" == "use" ]]; then
     shift
 
-    if [ ! -d "${DEVENVROOT}/flavors/$1" ]; then
+    if [ ! -d "${DEVENVFLAVORROOT}/$1" ]; then
       display "not hacking"
       return
     fi


### PR DESCRIPTION
* Related issue: #31

* Description:
With this PR you may define the `DEVENVFLAVORROOT` environment variable to point to the flavors path where you want.

* Example:

```bash
┌── .devenv [feat/customized-flavors-dir]
└─❯ export DEVENVFLAVORROOT=$HOME/.flavors
┌── .devenv [feat/customized-flavors-dir]
└─❯ source scripts/init
┌── .devenv [feat/customized-flavors-dir]
└─❯ devenv use issue31 
now using 'issue31'
┌── .devenv [feat/customized-flavors-dir] (issue31)
└─❯ env | grep ^DEVENV
DEVENVFLAVOR=issue31
DEVENVFLAVORROOT=/home/chestercheng/.flavors
DEVENVPATH_BACKUP=/home/chestercheng/.local/bin:/home/chestercheng/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl
DEVENVPREFIX=/home/chestercheng/.flavors/issue31/usr
DEVENVDLROOT=/home/chestercheng/.devenv/var/downloaded
DEVENVLIBRARY_PATH_BACKUP=
DEVENVROOT=/home/chestercheng/.devenv
┌── .devenv [feat/customized-flavors-dir] (issue31)
└─❯ echo $PATH
/home/chestercheng/.flavors/issue31/usr/bin:/home/chestercheng/.local/bin:/home/chestercheng/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl
```
