### PR TITLE
feat(launch): init support of launching applications

### DIFF
--- a/applications/solvcon/prepare-solvcon-dev.sh
+++ b/applications/solvcon/prepare-solvcon-dev.sh
@@ -11,7 +11,7 @@ if [ -z "${DEVENVFLAVOR}" ]
 then
   SOLVCON_PROJECT=${1:-${HOME}/solvcon}
 else
-  SOLVCON_PROJECT=${1:-${DEVENVAPPLICATION}}
+  SOLVCON_PROJECT=${1:-${DEVENVAPP}}
 fi
 
 SCSRC="${SOLVCON_PROJECT}/solvcon"

--- a/applications/solvcon/prepare-solvcon-dev.sh
+++ b/applications/solvcon/prepare-solvcon-dev.sh
@@ -6,7 +6,14 @@
 #   source <this script> <your-project-folder>
 #
 set -x
-SOLVCON_PROJECT=${1:-${HOME}/solvcon}
+
+if [ -z "${DEVENVFLAVOR}" ]
+then
+  SOLVCON_PROJECT=${1:-${HOME}/solvcon}
+else
+  SOLVCON_PROJECT=${1:-${DEVENVAPPLICATION}}
+fi
+
 SCSRC="${SOLVCON_PROJECT}/solvcon"
 SCSRC_WORKING="${SOLVCON_PROJECT}/solvcon-working"
 SCDE_SRC=${SCDE_SRC:-${SOLVCON_PROJECT}/devenv}
@@ -77,4 +84,12 @@ echo "======================================="
 pushd ${SCSRC}/sandbox/gas/tube
 ./go run
 popd
+
+
+# A workaround to use packages built or managed by conda.  We could abandon
+# this workaround when devenv is fully integrated and used for SOLVCON
+echo "Re-launch SOLVCON by the following commands:"
+echo ""
+echo "export PATH="${SCSRC}:${MINICONDA_DIR}/bin:${PATH}""
+echo ""
 

--- a/bin/devenv
+++ b/bin/devenv
@@ -21,11 +21,12 @@ Description:
 devenv management tool
 
 Commands:
-add   - create a new devenv environment
-use   - select an environment to use
-del   - delete an environment directory
-off   - deactivate environment
-build - build applications"
+add    - create a new devenv environment
+use    - select an environment to use
+del    - delete an environment directory
+off    - deactivate environment
+build  - build package
+launch - launch application"
 else
   display -e "Unrecognized command line argument: '${cmd}'"
 fi

--- a/scripts/application.d/solvcon
+++ b/scripts/application.d/solvcon
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -e
+
+application_name=solvcon
+application_branch=${VERSION:-master}
+application_full=$application_name-$application_branch
+application_src=${DEVENVROOT}/flavors/${DEVENVFLAVOR}/src/${application_full}
+
+syncgit https://github.com/solvcon ${application_name} ${application_branch}
+
+export DEVENVAPPLICATION=${DEVENVROOT}/flavors/${DEVENVFLAVOR}/application-${application_name}
+mkdir -p ${DEVENVAPPLICATION}
+
+ln -s ${application_src} ${DEVENVAPPLICATION}/${application_name}
+
+
+echo "launching solvcon..."
+${DEVENVROOT}/bin/build-application-solvcon-devenv.sh
+
+# vim: set et nobomb ft=bash ff=unix fenc=utf8:

--- a/scripts/application.d/solvcon
+++ b/scripts/application.d/solvcon
@@ -9,10 +9,10 @@ application_src=${DEVENVROOT}/flavors/${DEVENVFLAVOR}/src/${application_full}
 
 syncgit https://github.com/solvcon ${application_name} ${application_branch}
 
-export DEVENVAPPLICATION=${DEVENVROOT}/flavors/${DEVENVFLAVOR}/application-${application_name}
-mkdir -p ${DEVENVAPPLICATION}
+export DEVENVAPP=${DEVENVROOT}/flavors/${DEVENVFLAVOR}/application-${application_name}
+mkdir -p ${DEVENVAPP}
 
-ln -s ${application_src} ${DEVENVAPPLICATION}/${application_name}
+ln -s ${application_src} ${DEVENVAPP}/${application_name}
 
 
 echo "launching solvcon..."

--- a/scripts/cmd.d/launch
+++ b/scripts/cmd.d/launch
@@ -1,0 +1,17 @@
+. ${DEVENVROOT}/scripts/func.d/bash_utils
+
+script="${DEVENVROOT}/scripts/application.d/$1"
+if [ ! -f "${script}" ]; then
+  display -e "'$1' not defined"
+fi
+
+if [ -z "${DEVENVFLAVOR}" ] ; then
+  display -e "\$DEVENVFLAVOR not defined"
+fi
+
+. ${DEVENVROOT}/scripts/func.d/build_utils
+display "Execute building script \"${script}\" ${@:$(($#+1))} ..."
+. ${script}
+display "Finished building script \"${script}\"."
+
+# vim: set et nu nobomb fenc=utf8 ft=sh ff=unix sw=2 ts=2:

--- a/scripts/func.d/bash_utils
+++ b/scripts/func.d/bash_utils
@@ -18,6 +18,9 @@ get_list() {
     build)
       dir="${DEVENVROOT}/scripts/build.d"
       ;;
+    applicatioin)
+      dir="${DEVENVROOT}/scripts/application.d"
+      ;;
     cmd)
       dir="${DEVENVROOT}/scripts/cmd.d"
       ;;

--- a/scripts/func.d/bash_utils
+++ b/scripts/func.d/bash_utils
@@ -18,7 +18,7 @@ get_list() {
     build)
       dir="${DEVENVROOT}/scripts/build.d"
       ;;
-    applicatioin)
+    application)
       dir="${DEVENVROOT}/scripts/application.d"
       ;;
     cmd)

--- a/scripts/init
+++ b/scripts/init
@@ -52,6 +52,11 @@ _devenv() {
       COMPREPLY=( $(compgen -W "$(get_list build)" -- ${cur}) )
       return 0
       ;;
+    launch)
+      [[ $COMP_CWORD > 2 ]] && return 1
+      COMPREPLY=( $(compgen -W "$(get_list application)" -- ${cur}) )
+      return 0
+      ;;
     *)
       [[ $COMP_CWORD > 1 ]] && return 1
       cmds=$(get_list cmd)


### PR DESCRIPTION
In the [sciwork online sprint today](https://hackmd.io/UbOReM5CQcmtP5gL1zxqqw?view), this is the feature we have implemented for issue: #26 .

# Steps to Verify the Pull Request
1. `source scripts/init`
1. `devenv use flavor-issue-26`
1. `devenv launch solvcon`

# Expected Result
1. SOLVCON will be built
2. `flavor/flavor-issue-26/application-solvcon` is created

# Additioinaly Information
This pull request only closes https://github.com/solvcon/devenv/issues/26 but not fully completes https://github.com/solvcon/devenv/discussions/23 for the follow incomplete tasks and imperfect features:

1. Uses still need to manually re-launch SOLVCON
2. SOLVCON source and lib are not fully integrated with `flavor/usr/`, `flavor/usr/bin`, and `flavor/src`.

I will create follow-up pull requests to complete above tasks later on to prevent a single huge pull request for code review. Inputs are welcome.