### PR TITLE
feat: bzip2 script enhance

### DIFF
--- a/scripts/build.d/bzip2
+++ b/scripts/build.d/bzip2
@@ -9,7 +9,11 @@ git clone git://sourceware.org/git/bzip2.git ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}
 pushd ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src/${pkgname} > /dev/null
 
   INSTALL_PREFIX=${DEVENVPREFIX}
+  buildcmd make.log make -f Makefile-libbz2_so
+  buildcmd make.log make clean
   buildcmd make.log make install PREFIX=${INSTALL_PREFIX} -j ${NP}
+  cp libbz2.so.1.0.8 ${DEVENVPREFIX}/lib
+  ln -s ${DEVENVPREFIX}/lib/libbz2.so.1.0.8 ${DEVENVPREFIX}/lib/libbz2.so
 
 popd > /dev/null
 # vim: set et nobomb ft=bash ff=unix fenc=utf8:


### PR DESCRIPTION
When I tried to import `pandas` which will use bzip2 via shared library, but it can not find `libbz2.so`, so that I found the `bzip2` makefile only build the static library, it didn't build shared library.
If you want to build shared library, you need to call **another makefile**, and this makefile didn't help you to i**nstall shared library**, you need to install it **manually**, therefore I enhanced `bzip2` script.

here is the reference [link](http://www.iitk.ac.in/LDP/LDP/lfs/5.0/html/chapter06/bzip2.html)