### PR TITLE
Make devenv function to print the active environment

### DIFF
--- a/bin/devenv
+++ b/bin/devenv
@@ -20,6 +20,11 @@ elif [[ -z ${cmd} || ${cmd} = help ]]; then
 Description:
     Tool to manage development environment in console
 
+Variables:
+    DEVENVROOT=${DEVENVROOT}
+    DEVENVDLROOT=${DEVENVDLROOT}
+    DEVENVFLAVOR=${DEVENVFLAVOR}
+
 Commands:
     list   - list all available environments
     use    - activate an environment

--- a/bin/devenv
+++ b/bin/devenv
@@ -18,16 +18,16 @@ elif [[ -z ${cmd} || ${cmd} = help ]]; then
   display "Usage: ${0##*/} [command]
 
 Description:
-devenv management tool
+    Tool to manage development environment in console
 
 Commands:
-add    - create a new devenv environment
-list   - list all available devenv environments
-use    - select an environment to use
-del    - delete an environment directory
-off    - deactivate environment
-build  - build package
-launch - launch application"
+    list   - list all available environments
+    use    - activate an environment
+    off    - deactivate the environment
+    add    - create a new environment directory
+    del    - delete a existing environment directory
+    build  - build a package in the active environment
+    launch - launch an application"
 else
   display -e "Unrecognized command line argument: '${cmd}'"
 fi

--- a/scripts/init
+++ b/scripts/init
@@ -6,7 +6,13 @@ devenv() {
   . ${DEVENVROOT}/scripts/func.d/bash_utils
   . ${DEVENVROOT}/scripts/env.d/devenv_impl
 
-  if [[ "$1" == "use" ]]; then
+  if [[ "$1" == "" ]]; then
+    if [ -z "${DEVENVFLAVOR}" ] ; then
+      display "no active flavor: \$DEVENVFLAVOR not defined"
+    else
+      display "'${DEVENVFLAVOR}' is active: ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}"
+    fi
+  elif [[ "$1" == "use" ]]; then
     shift
 
     if [ ! -d "${DEVENVFLAVORROOT}/$1" ]; then
@@ -28,6 +34,8 @@ devenv() {
 
     display "'${DEVENVFLAVOR}' to be turned off"
     devenv_act nameremove ${DEVENVFLAVOR}
+  elif [[ "$1" == "help" ]]; then
+    ${DEVENVROOT}/bin/devenv "$@"
   else
     ${DEVENVROOT}/bin/devenv "$@"
   fi

--- a/scripts/init
+++ b/scripts/init
@@ -12,6 +12,8 @@ devenv() {
     else
       display "'${DEVENVFLAVOR}' is active: ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}"
     fi
+    display ""
+    ${DEVENVROOT}/bin/devenv help
   elif [[ "$1" == "use" ]]; then
     shift
 


### PR DESCRIPTION
Typing `devenv` alone showed only the help message but not the active environment.  With this PR, `devenv` alone shows the active environment:

```
$ devenv
'mainde' is active: /Users/yungyuc/.devenv/flavors/mainde
```

If there is not an active environment:

```
$ devenv
no active flavor: $DEVENVFLAVOR not defined
```