### PR TITLE
feat: enhance pip install sequence

### DIFF
--- a/scripts/build.d/python
+++ b/scripts/build.d/python
@@ -49,7 +49,18 @@ pushd ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src/${pkgfull} > /dev/null
   buildcmd make.log make build_all -j ${NP}
   buildcmd install.log make install
 
-  curl https://bootstrap.pypa.io/get-pip.py | ${PREFIX}/bin/python3
+  # check python version
+  PY_BIN=${PREFIX}/bin/python3
+  CURL_URL=https://bootstrap.pypa.io/get-pip.py
+
+  IFS='.' read -ra VER <<< ${VERSION}
+
+  if [[ ${VER[0]} == "v2" ]]; then
+    PY_BIN=${PREFIX}/bin/python
+    CURL_URL=https://bootstrap.pypa.io/pip/2.7/get-pip.py
+  fi
+
+  curl ${CURL_URL} | ${PY_BIN}
   rm -f ${PREFIX}/bin/pip
 
 popd > /dev/null


### PR DESCRIPTION
There are some little different when install `pip` between `python 2.7` and `python 3`,
this commit allow python build script at `pip` installing can compatible with `python2.7` and `python 3`.