### PR TITLE
fix(applications): sync up runtime flavors

### DIFF
--- a/bin/build-application-solvcon-devenv.sh
+++ b/bin/build-application-solvcon-devenv.sh
@@ -1,6 +1,6 @@
 # SCDE: SOLVCON Dev Env
 DEVENV_TOOL=${HOME}/solvcon/devenv
-DEVENV_FLAVOR="solvcon-devenv"
+DEVENV_FLAVOR=${DEVENVFLAVOR}
 SCDE_SRC=${DEVENV_TOOL}/applications/solvcon
 
 source ${SCDE_SRC}/prepare-solvcon-dev.sh


### PR DESCRIPTION
issue: #66

# Steps to Test This Pull Request
1. `devenv add flavor1`
2. `devenv use flavor1`
3. `devenv launch solvcon`

# Expected Result
The application `solvcon` is built and passes a quick self-test. `devenv show` only shows `flavor1` without the other flavor `solvcon-devenv`.