### PR TITLE
Add "DEVENVALIAS" variable to create an alias to "devenv" driver command

### DIFF
--- a/scripts/init
+++ b/scripts/init
@@ -79,4 +79,9 @@ _devenv() {
 }
 complete -F _devenv devenv
 
+if [ -n "${DEVENVALIAS}" ] ; then
+  alias ${DEVENVALIAS}=devenv
+  complete -F _devenv ${DEVENVALIAS}
+fi
+
 # vim: set et nu nobomb fenc=utf8 ft=bash ff=unix sw=2 ts=2:


### PR DESCRIPTION
`scripts/init` reads a new variable `DEVENVALIAS` that creates an alias to `devenv` and enables autocomplete for the alias.  To use the new feature provided in the patch, in `.bashrc`, add:

```bash
if [ -f ~/devenv/scripts/init ]; then
  DEVENVALIAS=sd
  source ~/devenv/scripts/init
fi
```

It enables:

```console
$ sd<tab>
add     build   del     launch  list    off     show    use
```

and 

```console
$ sd
no active flavor: $DEVENVFLAVOR not defined

Usage: devenv [command]

Description:
    Tool to manage development environment in console

...
```