### PR TITLE
Add usage of show

### DIFF
--- a/bin/devenv
+++ b/bin/devenv
@@ -33,7 +33,7 @@ Commands:
     del    - delete a existing environment directory
     build  - build a package in the active environment
     launch - launch an application
-    show   - print the current environment/flavor"
+    show   - print the current environment"
 
 else
   display -e "Unrecognized command line argument: '${cmd}'"

--- a/bin/devenv
+++ b/bin/devenv
@@ -32,7 +32,9 @@ Commands:
     add    - create a new environment directory
     del    - delete a existing environment directory
     build  - build a package in the active environment
-    launch - launch an application"
+    launch - launch an application
+    show   - print the current environment/flavor"
+
 else
   display -e "Unrecognized command line argument: '${cmd}'"
 fi


### PR DESCRIPTION
The usage of show is shown.

```
jenny@moria:~/devenv/bin$ devenv
no active flavor: $DEVENVFLAVOR not defined

Usage: devenv [command]

Description:
    Tool to manage development environment in console

Variables:
    DEVENVROOT=/home/jenny/devenv
    DEVENVDLROOT=/home/jenny/devenv/var/downloaded
    DEVENVFLAVOR=

Commands:
    list   - list all available environments
    use    - activate an environment
    off    - deactivate the environment
    add    - create a new environment directory
    del    - delete a existing environment directory
    build  - build a package in the active environment
    launch - launch an application
    show   - print the current environment/flavor
```