### PR TITLE
Add usage of show in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Commands:
     del    - delete a existing environment directory
     build  - build a package in the active environment
     launch - launch an application
+    show   - print the current environment
 ```
 
 There is no environment ("flavor") available in the beginning.  You need to


### PR DESCRIPTION
The usage of show is shown in README.md 


```
$ devenv
no active flavor: $DEVENVFLAVOR not defined

Usage: devenv [command]

Description:
    Tool to manage development environment in console

Variables:
    DEVENVROOT=/path/to
    DEVENVDLROOT=/path/to/var/downloaded
    DEVENVFLAVOR=

Commands:
    list   - list all available environments
    use    - activate an environment
    off    - deactivate the environment
    add    - create a new environment directory
    del    - delete a existing environment directory
    build  - build a package in the active environment
    launch - launch an application
    show   - print the current environment
```