### PR TITLE
Set DEVENVCURRENTROOT back to /dev/null after devenv off

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
-flavors
+flavors/
+tmp/
 var/downloaded
 *.swp

--- a/scripts/env.d/vars
+++ b/scripts/env.d/vars
@@ -1,5 +1,5 @@
 export DEVENVFLAVOR=""
-export DEVENVPREFIX=""
+export DEVENVPREFIX="/dev/null"
 export DEVENVPATH_BACKUP="${PATH}"
 export DEVENVDLROOT="${DEVENVROOT}/var/downloaded"
 export DEVENVFLAVORROOT="${DEVENVFLAVORROOT:-$DEVENVROOT/flavors}"

--- a/scripts/init
+++ b/scripts/init
@@ -35,8 +35,9 @@ devenv() {
       return
     fi
 
-    display "'${DEVENVFLAVOR}' to be turned off"
+    display "the flavor '${DEVENVFLAVOR}' to be turned off"
     devenv_act nameremove ${DEVENVFLAVOR}
+    export DEVENVCURRENTROOT="/dev/null"
   elif [[ "$1" == "help" ]]; then
     ${DEVENVROOT}/bin/devenv "$@"
   else

--- a/tests/test_bash_utils.sh
+++ b/tests/test_bash_utils.sh
@@ -1,4 +1,7 @@
-#!/usr/bin/env bash
+#!/bin/bash
+
+echo "*** test file: $(basename ${BASH_SOURCE[0]})"
+
 . ${DEVENVROOT}/scripts/func.d/bash_utils
 
 test_display_type() {
@@ -43,14 +46,22 @@ test_get_flavor_list() {
   flavor_name="shunit2"
   tmp_flavor="${DEVENVFLAVORROOT}/${flavor_name}"
 
+  if [ -d ${tmp_flavor} ] ; then
+    echo "${tmp_flavor} already exists; cannot test"
+    exit
+  fi
+
+  assertNotContains "${flavor_name}" "${actual}"
+
   # SETUP
-  mkdir -p ${tmp_flavor}
+  # Note: do NOT add -p.  Make it fail if the directory already exists.
+  mkdir "${tmp_flavor}"
 
   actual=$(get_list flavor)
-  assertEquals "${flavor_name}" "${actual}"
+  assertContains "${flavor_name}" "${actual}"
 
   # TEARDOWN
-  rmdir ${tmp_flavor}
+  rmdir "${tmp_flavor}"
 }
 
 # Load and run shUnit2.

--- a/tests/test_bash_utils.sh
+++ b/tests/test_bash_utils.sh
@@ -54,6 +54,7 @@ test_get_flavor_list() {
   assertNotContains "${actual}" "${flavor_name}"
 
   # SETUP
+  mkdir -p "${DEVENVFLAVORROOT}"
   # Note: do NOT add -p.  Make it fail if the directory already exists.
   mkdir "${tmp_flavor}"
 

--- a/tests/test_bash_utils.sh
+++ b/tests/test_bash_utils.sh
@@ -51,14 +51,14 @@ test_get_flavor_list() {
     exit
   fi
 
-  assertNotContains "${flavor_name}" "${actual}"
+  assertNotContains "${actual}" "${flavor_name}"
 
   # SETUP
   # Note: do NOT add -p.  Make it fail if the directory already exists.
   mkdir "${tmp_flavor}"
 
   actual=$(get_list flavor)
-  assertContains "${flavor_name}" "${actual}"
+  assertContains "${actual}" "${flavor_name}"
 
   # TEARDOWN
   rmdir "${tmp_flavor}"

--- a/tests/test_devenv_impl.sh
+++ b/tests/test_devenv_impl.sh
@@ -1,23 +1,25 @@
 #!/bin/bash
 
+echo "*** test file: $(basename ${BASH_SOURCE[0]})"
+
 test_namemunge() {
   mypath=path1
-  assertEquals "$mypath" "path1"
+  assertEquals "path1" "$mypath"
   . ${DEVENVROOT}/scripts/env.d/devenv_impl
   namemunge mypath path2
-  assertEquals "$mypath" "path2:path1"
+  assertEquals "path2:path1" "$mypath"
   namemunge mypath path3 after
-  assertEquals "$mypath" "path2:path1:path3"
+  assertEquals "path2:path1:path3" "$mypath"
 }
 
 test_nameremove() {
   mypath=path2:path1:path3
-  assertEquals "$mypath" "path2:path1:path3"
+  assertEquals "path2:path1:path3" "$mypath"
   . ${DEVENVROOT}/scripts/env.d/devenv_impl
   nameremove mypath path1
-  assertEquals "$mypath" "path2:path3"
+  assertEquals "path2:path3" "$mypath"
   nameremove mypath path2
-  assertEquals "$mypath" "path3"
+  assertEquals "path3" "$mypath"
 }
 
 # Load and run shUnit2.

--- a/tests/test_init_var.sh
+++ b/tests/test_init_var.sh
@@ -1,20 +1,30 @@
 #!/bin/bash
+
+echo "*** test file: $(basename ${BASH_SOURCE[0]})"
+
 expected_devenvroot="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 test_devenvroot() {
-  assertEquals ${DEVENVROOT} ${expected_devenvroot}
+  assertEquals "${expected_devenvroot}" "${DEVENVROOT}"
 }
 
 test_devenvflavor() {
-  assertEquals "${DEVENVFLAVOR}" ""
+  # Check for existence.
+  assertEquals foo ${DEVENVFLAVOR+foo}
 }
 
 test_devenvflavorroot() {
-  assertEquals ${DEVENVFLAVORROOT} ${expected_devenvroot}/flavors
+  assertEquals "${expected_devenvroot}/flavors" "${DEVENVFLAVORROOT}"
+}
+
+test_devenvcurrentroot() {
+  # Check for existence.
+  assertEquals foo "${DEVENVCURRENTROOT+foo}"
 }
 
 test_devenvlibrary_path_backup() {
-  assertEquals "${DEVENVLIBRARY_PATH_BACKUP}" ""
+  # Check for existence.
+  assertEquals foo ${DEVENVLIBRARY_PATH_BACKUP+foo}
 }
 
 test_devenvpath_backup() {
@@ -26,11 +36,11 @@ test_devenvpath_backup() {
 }
 
 test_devenvprefix() {
-  assertEquals "${DEVENVPREFIX}" ""
+  assertEquals /dev/null ${DEVENVPREFIX}
 }
 
 test_devenvdlroot() {
-  assertEquals ${DEVENVDLROOT} ${expected_devenvroot}/var/downloaded
+  assertEquals ${expected_devenvroot}/var/downloaded ${DEVENVDLROOT}
 }
 
 # Load and run shUnit2.


### PR DESCRIPTION
Before using a flavor:

```console
$ devenv
no active flavor: $DEVENVFLAVOR not defined

Usage: devenv [command]

Description:
    Tool to manage development environment in console

Variables:
    DEVENVROOT=/Users/yungyuc/work/devenv
    DEVENVDLROOT=/Users/yungyuc/work/devenv/var/downloaded
    DEVENVFLAVOR=
    DEVENVFLAVORROOT=/Users/yungyuc/work/devenv/flavors
    DEVENVCURRENTROOT=/dev/null
```

After using a flavor:

```console
$ devenv use prime ; devenv
now using 'prime'
'prime' is active: /Users/yungyuc/work/devenv/flavors/prime

Usage: devenv [command]

Description:
    Tool to manage development environment in console

Variables:
    DEVENVROOT=/Users/yungyuc/work/devenv
    DEVENVDLROOT=/Users/yungyuc/work/devenv/var/downloaded
    DEVENVFLAVOR=prime
    DEVENVFLAVORROOT=/Users/yungyuc/work/devenv/flavors
    DEVENVCURRENTROOT=/Users/yungyuc/work/devenv/flavors/prime
```

After turning off, `DEVENVCURRENTROOT` is back to `/dev/null`:

```console
$ devenv off ; devenv
the flavor 'prime' to be turned off
no active flavor: $DEVENVFLAVOR not defined

Usage: devenv [command]

Description:
    Tool to manage development environment in console

Variables:
    DEVENVROOT=/Users/yungyuc/work/devenv
    DEVENVDLROOT=/Users/yungyuc/work/devenv/var/downloaded
    DEVENVFLAVOR=
    DEVENVFLAVORROOT=/Users/yungyuc/work/devenv/flavors
    DEVENVCURRENTROOT=/dev/null
```

Other changes.

* Default `DEVENVPREFIX` to `/dev/null` to prevent accidentally adding files to the working directory.
* Add a unit test function for the existence of  `DEVENVCURRENTROOT`.
* Make unit tests pass even when devenv is in use.