### PR TITLE
feat(build): python: provide more hints for prerequisite

### DIFF
--- a/scripts/build.d/python
+++ b/scripts/build.d/python
@@ -6,6 +6,15 @@ pkgname=cpython
 pkgbranch=${VERSION:-main}
 pkgfull=${pkgname}
 
+trap 'get_pip $? $LINENO' ERR
+
+get_pip() {
+  echo "When failing to download pip, if you got warning messages like:"
+  echo "    pip is configured with locations that require TLS/SSL, however the ssl module in Python is not available."
+  echo "You may need OpenSSL lib in your flavor. Build OpenSSL with devenv by:"
+  echo "    $ devenv build openssl"
+}
+
 syncgit https://github.com/python ${pkgname} ${pkgbranch} ${pkgfull}
 
 pushd ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src/${pkgfull} > /dev/null


### PR DESCRIPTION
# Description
Run into errors when building python with `devenv build python`:

```
<skipped>                                                                                                                            
Could not build the ssl module!
Python requires a OpenSSL 1.1.1 or newer
<skipped>
WARNING: pip is configured with locations that require TLS/SSL, however the ssl module in Python is not available.
WARNING: Retrying (Retry(total=4, connect=None, read=None, redirect=None, status=None)) after connection broken by 'SSLError("Can't connect to HTTPS URL because the SSL module is not available.")': /simple/pip/
WARNING: Retrying (Retry(total=3, connect=None, read=None, redirect=None, status=None)) after connection broken by 'SSLError("Can't connect to HTTPS URL because the SSL module is not available.")': /simple/pip/
WARNING: Retrying (Retry(total=2, connect=None, read=None, redirect=None, status=None)) after connection broken by 'SSLError("Can't connect to HTTPS URL because the SSL module is not available.")': /simple/pip/
WARNING: Retrying (Retry(total=1, connect=None, read=None, redirect=None, status=None)) after connection broken by 'SSLError("Can't connect to HTTPS URL because the SSL module is not available.")': /simple/pip/
WARNING: Retrying (Retry(total=0, connect=None, read=None, redirect=None, status=None)) after connection broken by 'SSLError("Can't connect to HTTPS URL because the SSL module is not available.")': /simple/pip/
Could not fetch URL https://pypi.org/simple/pip/: There was a problem confirming the ssl certificate: HTTPSConnectionPool(host='pypi.org', port=443): Max retries exceeded with url: /simple/pip/ (Caused by SSLError("Can't connect to HTTPS
 URL because the SSL module is not available.")) - skipping
ERROR: Could not find a version that satisfies the requirement pip (from versions: none)
ERROR: No matching distribution found for pip
```

# Steps to Reproduce
1. build and launch an usual `devenv` flavor from scratch
2. `devenv build python`

# Expected Result
No error message is raised.

# Actual Result
See Description for the error messages.