### PR TITLE
Add a test of get_list type

### DIFF
--- a/tests/test_bash_utils.sh
+++ b/tests/test_bash_utils.sh
@@ -24,6 +24,12 @@ test_display_e() {
   assertEquals "${expected_return_code}" "${actual_return_code}"
 }
 
+test_get_list_type() {
+  expected="get_list is a function"
+  actual=$(type get_list | grep "is a")
+  assertEquals "${expected}" "${actual}"
+}
+
 test_get_cmd_list() {
   expected=$(echo `${LS_PATH} -1 ../scripts/cmd.d/`)
   actual=$(get_list cmd)


### PR DESCRIPTION
I added a test `test_get_list_type()` in `tests/test_bash_utils.sh` to test whether the `get_list` is a function.

Because I found `display` and `get_list` are the functions defined in `bash_utils` file, but there is just a test for `display` in `tests/test_bash_utils.sh`. Thus, I add one for `get_list`.

Here is the test I added:
```
test_get_list_type() {
  expected="get_list is a function"
  actual=$(type get_list | grep "is a")
  assertEquals "${expected}" "${actual}"
}
``` 


The tests are passed after running `./runner.sh`
```
jenny@moria:~/devenv/tests$ ./runner.sh
*** test file: test_init_var.sh
test_devenvroot
test_devenvflavor
test_devenvflavorroot
test_devenvcurrentroot
test_devenvlibrary_path_backup
test_devenvpath_backup
test_devenvprefix
test_devenvdlroot

Ran 8 tests.

OK
*** test file: test_bash_utils.sh
test_display_type
test_display
test_display_e
devenv shunit2 unittest
test_get_list_type
test_get_cmd_list
test_get_build_list
test_get_application_list
test_get_flavor_list

Ran 8 tests.

OK
*** test file: test_devenv_impl.sh
test_namemunge
test_nameremove

Ran 2 tests.

OK
```

Any suggestions and comments are welcome!