### PR TITLE
fix: fixed devenv flavor root bug

### DIFF
--- a/scripts/env.d/vars
+++ b/scripts/env.d/vars
@@ -2,7 +2,7 @@ export DEVENVFLAVOR=""
 export DEVENVPREFIX="/dev/null"
 export DEVENVPATH_BACKUP="${PATH}"
 export DEVENVDLROOT="${DEVENVROOT}/var/downloaded"
-export DEVENVFLAVORROOT="${DEVENVFLAVORROOT:-$DEVENVROOT/flavors}"
+export DEVENVFLAVORROOT="$DEVENVROOT/flavors"
 export DEVENVCURRENTROOT="/dev/null"
 case "$(uname)" in
   Darwin)


### PR DESCRIPTION
If user source multiple times `devenv` `init` script, the environment var `DEVENVFLAVORROOT` used by `devenv` will use the older `DEVENVFLAVORROOT`,  if the environment var exists.

