### PR TITLE
enhance: refurbished bzip2 build script

### DIFF
--- a/scripts/build.d/bzip2
+++ b/scripts/build.d/bzip2
@@ -3,17 +3,22 @@
 set -e
 
 pkgname=bzip2
+pkgbranch=${VERSION:-master}
+pkgfull=$pkgname-$pkgbranch
 
-git clone git://sourceware.org/git/bzip2.git ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src/${pkgname}
+syncgit https://gitlab.com/bzip2 ${pkgname} ${pkgbranch} ${pkgfull}
 
-pushd ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src/${pkgname} > /dev/null
+pushd ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src/${pkgfull} > /dev/null
+  mkdir -p build
+  pushd build > /dev/null
+    cmakecmd=("cmake")
+    cmakecmd+=("-DCMAKE_INSTALL_PREFIX=${DEVENVPREFIX}")
+    cmakecmd+=("-DENABLE_SHARED_LIB=ON")
+    cmakecmd+=("../")
 
-  INSTALL_PREFIX=${DEVENVPREFIX}
-  buildcmd make.log make -f Makefile-libbz2_so
-  buildcmd make.log make clean
-  buildcmd make.log make install PREFIX=${INSTALL_PREFIX} -j ${NP}
-  cp libbz2.so.1.0.8 ${DEVENVPREFIX}/lib
-  ln -s ${DEVENVPREFIX}/lib/libbz2.so.1.0.8 ${DEVENVPREFIX}/lib/libbz2.so
-
+    buildcmd cmake.log "${cmakecmd[@]}"
+    buildcmd make.log make -j ${NP}
+    buildcmd install.log make install
+  popd > /dev/null
 popd > /dev/null
 # vim: set et nobomb ft=bash ff=unix fenc=utf8:


### PR DESCRIPTION
The root cause of https://github.com/solvcon/devenv/issues/92 is bzip2 using `-soname` as `LDFLAGS` in makefile, but MacOS default C compiler is clang and the `LDFLAGS` is `-install_name`, so devenv failed to build bzip2 at MacOS.

It seems bzip2 currently migrated from [sourceware](https://sourceware.org/git/?p=bzip2.git;a=summary) to [gitlab](https://gitlab.com/bzip2/bzip2), and it using `CMake` instead of pure `Makefile`, so I refurbished `bzip2` build script.

Here is the result of GitHub workflow : [Result](https://github.com/j8xixo12/devenv/runs/4131291353?check_suite_focus=true#step:4:36254)