### PR TITLE
Revive the SOLVCON application - regular maintenance

### DIFF
--- a/applications/solvcon/entry.sh
+++ b/applications/solvcon/entry.sh
@@ -30,6 +30,10 @@ devenv use ${DEVENVFLAVOR_SUB}
 # bz2 will be used by solvcon (via python)
 devenv build openssl
 devenv build bzip2
+# sqlite will be used when building python on mac OS for:
+#     error: System version of SQLite does not support loadable extensions
+#     make: *** [sharedmods] Error 1
+devenv build sqlite
 VERSION=3.8 devenv build python
 devenv build cmake
 # scotch will be used later by libmarch

--- a/applications/solvcon/entry.sh
+++ b/applications/solvcon/entry.sh
@@ -34,7 +34,7 @@ VERSION=3.8 devenv build python
 devenv build cmake
 # scotch will be used later by libmarch
 # cmake will be used for building scotch
-devenv build scotch
+SYNCGIT="yes" devenv build scotch
 
 # prepare all packages to build SOLVCON
 pip3 install nose boto paramiko netCDF4 numpy


### PR DESCRIPTION
Since https://github.com/solvcon/devenv/pull/93 has landed to unblock the SOLVCON CI build of mac OS, the rest tasks should be merged to build SOLVCON by devenv[1].


[1] Verified by https://github.com/tai271828/solvcon/runs/4137753217?check_suite_focus=true