### PR TITLE
Create CI jobs to monitor the build process of scotch

### DIFF
--- a/.github/workflows/build_pkg_runner.yml
+++ b/.github/workflows/build_pkg_runner.yml
@@ -1,0 +1,32 @@
+name: Package Built by devenv
+on:
+  schedule:
+    - cron: '21 18 * * 5'
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+        matrix:
+          os: [ubuntu-18.04, macos-latest]
+        fail-fast: false
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+    - name: Scotch - tarball build
+      run: |
+        working_flavor=scotch-tarball
+        source ${GITHUB_WORKSPACE}/scripts/init
+        devenv add ${working_flavor}
+        devenv use ${working_flavor}
+        devenv show
+        devenv build scotch
+    - name: Scotch - git repository
+      run: |
+        working_flavor=scotch-syncgit
+        source ${GITHUB_WORKSPACE}/scripts/init
+        devenv add ${working_flavor}
+        devenv use ${working_flavor}
+        devenv show
+        SYNCGIT="yes" devenv build scotch


### PR DESCRIPTION
When working on https://github.com/solvcon/devenv/issues/98 , I realized this issue https://github.com/solvcon/devenv/issues/101 is a part of #98 . This pull request will create new CI job to monitor any future regression like #101 .

Please note currently the build with git branch source on macOS will fail. This is expected because of #101 .