### PR TITLE
ci(SOLVCON): introduce DEVENV_WORKSPACE

### DIFF
--- a/.github/workflows/solvcon_runner.yml
+++ b/.github/workflows/solvcon_runner.yml
@@ -14,66 +14,29 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 1
+    - name: Set DEVENV_WORKSPACE
+      run: echo "DEVENV_WORKSPACE=${GITHUB_WORKSPACE}" >> $GITHUB_ENV
     - name: Configure SSH
       if: matrix.os == 'disable'
       run: |
-        ssh-keygen -t rsa -f ~/.ssh/id_rsa -N ""
-        chmod 700 ~/.ssh/
-        cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
-        chmod 600 ~/.ssh/authorized_keys
-        ssh-keyscan -t rsa localhost >> ~/.ssh/known_hosts
-        ssh-keyscan -t rsa 127.0.0.1 >> ~/.ssh/known_hosts
-        chmod 600 ~/.ssh/known_hosts
-        ls -al ~/.ssh/
-        ssh localhost ls
-        ssh 127.0.0.1 ls
+        source contrib/ci-setup-ssh.sh
     - name: Dependency (Ubuntu)
       if: matrix.os != 'macos-latest'
       run: |
-        sudo apt-get -qqy update
-        sudo apt-get -qqy install fakeroot debhelper locales \
-                libffi-dev \
-                liblapack3 liblapack-dev
+        source ${DEVENV_WORKSPACE}/contrib/ci-setup-apt.sh
     - name: Launch SOLVCON
       run: |
-        source ${GITHUB_WORKSPACE}/scripts/init
+        source ${DEVENV_WORKSPACE}/scripts/init
         devenv add prime
         devenv use prime
         devenv show
         devenv launch solvcon
     - name: Show Dependency
       run: |
-        source ${GITHUB_WORKSPACE}/scripts/init
-        devenv use prime
-        devenv show
-        export
-        which gcc
-        gcc --version
-        which cmake
-        cmake --version
-        which python3
-        python3 --version
-        python3 -c 'import numpy ; print("numpy.__version__:", numpy.__version__)'
-        which gmsh
+        source ${DEVENV_WORKSPACE}/contrib/ci-show-dep.sh
     - name: Show Python Env
       run: |
-        source ${GITHUB_WORKSPACE}/scripts/init
-        devenv use prime
-        devenv show
-        which python3
-        python3 --version
-        python3 -c 'import numpy ; print("numpy.__version__:", numpy.__version__)'
-        python3 -c 'import sys ; print(sys.path)'
-        echo "==============="
-        echo "python globals:"
-        python3 -c 'import numpy, solvcon ; print(globals())'
-        echo "==============="
-        echo "python locals:"
-        python3 -c 'import numpy, solvcon ; print(locals())'
-    - name: SOLVCON Function Test
+        source ${DEVENV_WORKSPACE}/contrib/ci-show-python-env.sh
+    - name: SOLVCON Function Test From Package
       run: |
-        source ${GITHUB_WORKSPACE}/scripts/init
-        devenv use prime
-        devenv show
-        cd ${DEVENVCURRENTROOT}/application-solvcon/solvcon/
-        make SC_PURE_PYTHON=1 test_from_package
+        source ${DEVENV_WORKSPACE}/contrib/ci-solvcon-function-test.sh

--- a/contrib/ci-setup-apt.sh
+++ b/contrib/ci-setup-apt.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 sudo apt-get -qqy update
 sudo apt-get -qqy install \
-	fakeroot debhelper locales \
+        fakeroot debhelper locales \
         libffi-dev \
         liblapack3 liblapack-dev

--- a/contrib/ci-setup-apt.sh
+++ b/contrib/ci-setup-apt.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+sudo apt-get -qqy update
+sudo apt-get -qqy install \
+	fakeroot debhelper locales \
+        libffi-dev \
+        liblapack3 liblapack-dev

--- a/contrib/ci-setup-ssh.sh
+++ b/contrib/ci-setup-ssh.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+ssh-keygen -t rsa -f ~/.ssh/id_rsa -N ""
+chmod 700 ~/.ssh/
+cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
+chmod 600 ~/.ssh/authorized_keys
+ssh-keyscan -t rsa localhost >> ~/.ssh/known_hosts
+ssh-keyscan -t rsa 127.0.0.1 >> ~/.ssh/known_hosts
+chmod 600 ~/.ssh/known_hosts
+ls -al ~/.ssh/
+ssh localhost ls
+ssh 127.0.0.1 ls

--- a/contrib/ci-show-dep.sh
+++ b/contrib/ci-show-dep.sh
@@ -1,4 +1,10 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
+set -eo pipefail
+if [ -z "${DEVENV_WORKSPACE}" ]; then
+  echo DEVENV_WORKSPACE is not available. Abort!
+  exit 1
+fi
+
 source ${DEVENV_WORKSPACE}/scripts/init
 
 devenv use prime

--- a/contrib/ci-show-dep.sh
+++ b/contrib/ci-show-dep.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/bash
+source ${DEVENV_WORKSPACE}/scripts/init
+
+devenv use prime
+devenv show
+export
+
+which gcc
+gcc --version
+
+which cmake
+cmake --version
+
+which gmsh

--- a/contrib/ci-show-python-env.sh
+++ b/contrib/ci-show-python-env.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+source ${DEVENV_WORKSPACE}/scripts/init
+
+devenv use prime
+devenv show
+which python3
+python3 --version
+python3 -c 'import numpy ; print("numpy.__version__:", numpy.__version__)'
+python3 -c 'import sys ; print(sys.path)'
+
+echo "==============="
+echo "python globals:"
+python3 -c 'import numpy, solvcon ; print(globals())'
+echo
+
+echo "==============="
+echo "python locals:"
+python3 -c 'import numpy, solvcon ; print(locals())'
+echo

--- a/contrib/ci-show-python-env.sh
+++ b/contrib/ci-show-python-env.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+set -eo pipefail
+if [ -z "${DEVENV_WORKSPACE}" ]; then
+  echo DEVENV_WORKSPACE is not available. Abort!
+  exit 1
+fi
+
 source ${DEVENV_WORKSPACE}/scripts/init
 
 devenv use prime

--- a/contrib/ci-solvcon-function-test.sh
+++ b/contrib/ci-solvcon-function-test.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+set -eo pipefail
+if [ -z "${DEVENV_WORKSPACE}" ]; then
+  echo DEVENV_WORKSPACE is not available. Abort!
+  exit 1
+fi
+
 source ${DEVENV_WORKSPACE}/scripts/init
 
 devenv use prime

--- a/contrib/ci-solvcon-function-test.sh
+++ b/contrib/ci-solvcon-function-test.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+source ${DEVENV_WORKSPACE}/scripts/init
+
+devenv use prime
+devenv show
+
+cd ${DEVENVCURRENTROOT}/application-solvcon/solvcon/
+make SC_PURE_PYTHON=1 test_from_package


### PR DESCRIPTION
By using this environment variable, we add a compatibility layer to make
the helper scripts more general so they can be used in different
GITHUB_WORKSPACE.

Please note the trick of GITHUB_ENV. It is a CVE alternative. See
document of Github like:
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

Issue: #99