### PR TITLE
Upgrade OpenSSL to 1.1.1m to support Apple Silicon

### DIFF
--- a/scripts/build.d/openssl
+++ b/scripts/build.d/openssl
@@ -5,12 +5,12 @@ set -e
 if [ -z "${SYNCGIT}" ]; then
 
   pkgname=openssl
-  pkgver=${VERSION:-1.1.1b}
+  pkgver=${VERSION:-1.1.1m}
   pkgfull=$pkgname-$pkgver
   pkgfn=$pkgfull.tar.gz
   pkgurl=https://www.openssl.org/source/$pkgfn
 
-  download_md5 $pkgfn $pkgurl 4532712e7bcc9414f5bce995e4e13930
+  download_md5 $pkgfn $pkgurl 8ec70f665c145c3103f6e330f538a9db
 
   mkdir -p ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src
   pushd ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src

--- a/scripts/build.d/python
+++ b/scripts/build.d/python
@@ -47,6 +47,7 @@ pushd ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src/${pkgfull} > /dev/null
     cfgcmd+=("LLVM_AR=/usr/bin/ar")
   fi
 
+  # Some Python extension does not work properly without this, e.g., pandas.
   cfgcmd+=("--enable-loadable-sqlite-extensions")
 
   if [[ ${DEVENVFLAVOR} == dbg* ]] ; then


### PR DESCRIPTION
The building arguments for Apple Silicon was added after OpenSSL 1.1.1g.  Upgrade to the latest 1.1.1m to support Apple Silicon.