### PR TITLE
When building scotch with git, use the same version as the tarball in CI

### DIFF
--- a/scripts/build.d/scotch
+++ b/scripts/build.d/scotch
@@ -17,7 +17,7 @@ if [ -z "${SYNCGIT}" ]; then
   tar xf ${DEVENVDLROOT}/$pkgfn
 else
   pkgname=scotch
-  pkgbranch=${VERSION:-master}
+  pkgbranch=${VERSION:-v6.1.0}
   pkgfull=${pkgname}-${pkgbranch}
 
   # unpack (clone / pull)


### PR DESCRIPTION
Succeeding implementation for issue https://github.com/solvcon/devenv/issues/101#issuecomment-1039934241

Tested with https://github.com/tai271828/devenv/runs/5224295939?check_suite_focus=true