### PR TITLE
Fix hdf5 build

### DIFF
--- a/.github/workflows/build_pkg_runner.yml
+++ b/.github/workflows/build_pkg_runner.yml
@@ -30,3 +30,11 @@ jobs:
         devenv use ${working_flavor}
         devenv show
         SYNCGIT="yes" devenv build scotch
+    - name: hdf5 - git repository
+      run: |
+        working_flavor=hdf5-syncgit
+        source ${GITHUB_WORKSPACE}/scripts/init
+        devenv add ${working_flavor}
+        devenv use ${working_flavor}
+        devenv show
+        devenv build hdf

--- a/scripts/build.d/hdf
+++ b/scripts/build.d/hdf
@@ -3,7 +3,7 @@
 set -e
 
 pkgname=hdf5
-pkgbranch=${VERSION:-1.8/master}
+pkgbranch=${VERSION:-hdf5_1_8}
 pkgfull=${pkgname}-${pkgbranch}
 
 # unpack (clone / pull)


### PR DESCRIPTION
It seems the naming convention of hdf5 upstream repository changed. Update the naming convention to revive the build.