### PR TITLE
Update Python build script

### DIFF
--- a/scripts/build.d/openssl
+++ b/scripts/build.d/openssl
@@ -2,7 +2,9 @@
 
 set -e
 
-if [ -z "${SYNCGIT}" ]; then
+SRCSYNC=${SRCSYNC:-tarball}
+
+if [ "${SRCSYNC}" == "tarball" ] ; then
 
   pkgname=openssl
   pkgver=${VERSION:-1.1.1m}
@@ -17,13 +19,18 @@ if [ -z "${SYNCGIT}" ]; then
     tar xf ${DEVENVDLROOT}/$pkgfn
   popd
 
-else
+elif [ "${SRCSYNC}" == "git" ] ; then
 
   pkgname=openssl
   pkgbranch=${VERSION:-master}
   pkgfull=${pkgname}
 
   syncgit https://github.com/openssl ${pkgname} ${pkgbranch} ${pkgfull}
+
+else
+
+  display -e "Invalid \${SRCSYNC} ${SRCSYNC}"
+  exit
 
 fi
 

--- a/scripts/build.d/python
+++ b/scripts/build.d/python
@@ -2,9 +2,7 @@
 
 set -e
 
-pkgname=cpython
-pkgbranch=${VERSION:-main}
-pkgfull=${pkgname}
+SRCSYNC=${SRCSYNC:-tarball}
 
 trap 'get_pip $? $LINENO' ERR
 
@@ -15,11 +13,41 @@ get_pip() {
   echo "    $ devenv build openssl"
 }
 
-syncgit https://github.com/python ${pkgname} ${pkgbranch} ${pkgfull}
+if [ "${SRCSYNC}" == "tarball" ] ; then
+
+  pkgname=Python
+  pkgver=${VERSION:-3.11.1}
+  pkgfull=${pkgname}-${pkgver}
+  pkgfn=${pkgfull}.tar.xz
+  pkgurl=https://www.python.org/ftp/python/${pkgver}/${pkgfn}
+
+  download_md5 $pkgfn $pkgurl 4efe92adf28875c77d3b9b2e8d3bc44a
+
+  mkdir -p ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src
+  pushd ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src > /dev/null
+    tar xf ${DEVENVDLROOT}/$pkgfn
+  popd > /dev/null
+
+elif [ "${SRCSYNC}" == "git" ] ; then
+
+  pkgname=cpython
+  pkgbranch=${VERSION:-master}
+  pkgfull=${pkgname}
+
+  # unpack (clone)
+  syncgit https://github.com/python ${pkgname} ${pkgbranch} ${pkgfull}
+
+else
+
+  display -e "Invalid \${SRCSYNC} ${SRCSYNC}"
+  exit
+
+fi
+
+# build.
 
 pushd ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src/${pkgfull} > /dev/null
 
-  # build
   PREFIX=${DEVENVPREFIX}
   ARCH=64
 
@@ -56,8 +84,8 @@ pushd ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src/${pkgfull} > /dev/null
 
   # build.
   buildcmd configure.log "${cfgcmd[@]}"
-  buildcmd make.log make build_all -j ${NP}
-  buildcmd install.log make install
+  buildcmd test.log make test -j ${NP}
+  buildcmd install.log make install -j ${NP}
 
   # check python version
   PY_BIN=${PREFIX}/bin/python3

--- a/scripts/func.d/build_utils
+++ b/scripts/func.d/build_utils
@@ -17,7 +17,7 @@ download_md5 () {
     mkdir -p $(dirname $loc)
     rm -f $loc
     echo "Download from $url"
-    curl -sSL -o $loc $url
+    curl -sSL ${CURLARGS} -o $loc $url
   fi
   local md5hash_calc=`$md5 $loc | cut -d ' ' -f 1`
   if [ $md5hash != $md5hash_calc ] ; then


### PR DESCRIPTION
* Upgrade and fix the Python build script to version 3.11.1.  Make pulling from git opt-in.
* Fix the openssl version by default.  Make pulling from git opt-in.
* Add an optional CURLARGS environment for adding "-k" to override bad certificate when downloading.