### PR TITLE
add command: list all support packages

### DIFF
--- a/scripts/cmd.d/packages
+++ b/scripts/cmd.d/packages
@@ -1,0 +1,6 @@
+. ${DEVENVROOT}/scripts/func.d/bash_utils
+
+devenv_display "Packages supported by devenv:";
+devenv_display "$(get_list build)";
+
+# vim: set et nu nobomb fenc=utf8 ft=bash ff=unix sw=2 ts=2:


### PR DESCRIPTION
Add a command, `packages`, which will list all the packages supported by `devenv`.
These packages can be build with `devenv build`.
<img width="1312" alt="Screenshot 2023-01-16 at 3 14 34 PM" src="https://user-images.githubusercontent.com/6830390/212619020-8a65b2c4-1095-448e-8fee-0524633b8660.png">
