### PR TITLE
fix: egrep is obsolescent

### DIFF
--- a/scripts/env.d/devenv_impl
+++ b/scripts/env.d/devenv_impl
@@ -1,5 +1,5 @@
 devenv_namemunge() {
-  if ! echo ${!1} | egrep -q "(^|:)$2($|:)" ; then
+  if ! echo ${!1} | grep -q -E "(^|:)$2($|:)" ; then
     if [ -z "${!1}" ] ; then
       eval "$1=$2"
     else


### PR DESCRIPTION
since egrep commnad has been deprecate, it should use `grep -E` instead. 

ref: https://www.phoronix.com/news/GNU-Grep-3.8-Stop-egrep-fgrep