### PR TITLE
Add $BUILDTEST to determine whether to run 'make test' for vim & python build scripts

### DIFF
--- a/scripts/build.d/python
+++ b/scripts/build.d/python
@@ -84,7 +84,7 @@ pushd ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src/${pkgfull} > /dev/null
 
   # build.
   buildcmd configure.log "${cfgcmd[@]}"
-  buildcmd test.log make test -j ${NP}
+  [ ! -z "$BUILDTEST" ] && buildcmd test.log make test -j ${NP}
   buildcmd install.log make install -j ${NP}
 
   # check python version

--- a/scripts/build.d/vim
+++ b/scripts/build.d/vim
@@ -47,7 +47,7 @@ pushd ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src/${pkgfull} > /dev/null
 
   buildcmd configure.log "${cfgcmd[@]}"
   buildcmd make.log make -j $NP
-  buildcmd test.log make test -j $NP
+  [ ! -z "$BUILDTEST" ] && buildcmd test.log make test -j $NP
   buildcmd install.log make install
 
 popd > /dev/null


### PR DESCRIPTION
I also found there's another `make test` in the build script of python, so I also modified it.