### PR TITLE
Qt build script update

### DIFF
--- a/scripts/build.d/qt
+++ b/scripts/build.d/qt
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
+#
+# Usage: devenv build qt
+#
+# extracting qt source code in HOME is very slow on NCHC machine,
+# to use other src path: QTSRC=/path/to/src devenv build qt.
+# for example: QTSRC=/tmp devenv build qt
+#
 
 set -e
+
+QTSRC=${QTSRC:-${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src}
 
 if [ -z "${SYNCGIT}" ]; then
   pkgname=qt
@@ -14,17 +23,14 @@ if [ -z "${SYNCGIT}" ]; then
   pkgfn=$pkgfull.tar.xz
   pkgurl=https://download.qt.io/official_releases/qt/$pkgmajorver/$pkgver/single/qt-everywhere-src-$pkgver.tar.xz
 
-  pkgsrc=${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src
-  #pkgsrc=/tmp
-
   download_md5 $pkgfn $pkgurl $pkgmd5
 
-  mkdir -p $pkgsrc
-  if [ -d $pkgsrc/$pkgfull ];
+  mkdir -p ${QTSRC}
+  if [ -d ${QTSRC}/$pkgfull ];
   then
-    echo "$pkgfull already exist, skip extract"
+    echo "QTSRC: ${QTSRC}/$pkgfull already exist, skip extract"
   else
-    pushd $pkgsrc > /dev/null
+    pushd ${QTSRC} > /dev/null
     tar xf ${DEVENVDLROOT}/$pkgfn
     mv $pkgfoler $pkgfull
     popd
@@ -40,13 +46,13 @@ fi
 
 # remove symlink check
 # https://github.com/Homebrew/homebrew-core/blob/29bc842d5cdffde2917bce61a1d4eb742cf6d987/Formula/qt.rb#L133
-pushd $pkgsrc/${pkgfull}
+pushd ${QTSRC}/${pkgfull}
   git apply -v --directory qtbase ${DEVENVROOT}/var/patch/${pkgfull}.patch || true
 popd
 
-rm -rf $pkgsrc/${pkgfull}/build # clean up previous build
-mkdir -p $pkgsrc/${pkgfull}/build
-pushd $pkgsrc/${pkgfull}/build
+rm -rf ${QTSRC}/${pkgfull}/build # clean up previous build
+mkdir -p ${QTSRC}/${pkgfull}/build
+pushd ${QTSRC}/${pkgfull}/build
   if [ -n "${SYNCGIT}" ]; then
     if [[ -z "$(command -v perl)" ]]; then
        echo "perl not exist!"

--- a/scripts/build.d/qt
+++ b/scripts/build.d/qt
@@ -2,14 +2,18 @@
 #
 # Usage: devenv build qt
 #
-# extracting qt source code in HOME is very slow on NCHC machine,
-# to use other src path: QTSRC=/path/to/src devenv build qt.
-# for example: QTSRC=/tmp devenv build qt
+# 1. extracting qt source code in HOME is very slow on NCHC machine,
+#    to use other src path: QTSRC=/path/to/src devenv build qt.
+#    for example: QTSRC=/tmp devenv build qt
+#
+# 2. extraction is set by default,
+#    to skip extract: SKIPEXTRACT=1 devenv build qt
 #
 
 set -e
 
 QTSRC=${QTSRC:-${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src}
+SKIPEXTRACT=${SKIPEXTRACT:-0}
 
 if [ -z "${SYNCGIT}" ]; then
   pkgname=qt
@@ -26,7 +30,7 @@ if [ -z "${SYNCGIT}" ]; then
   download_md5 $pkgfn $pkgurl $pkgmd5
 
   mkdir -p ${QTSRC}
-  if [ -d ${QTSRC}/$pkgfull ];
+  if [ -d ${QTSRC}/$pkgfull ] && [ ${SKIPEXTRACT} -eq 1 ];
   then
     echo "QTSRC: ${QTSRC}/$pkgfull already exist, skip extract"
   else

--- a/scripts/build.d/qt
+++ b/scripts/build.d/qt
@@ -38,6 +38,12 @@ else
   syncgit git://code.qt.io/qt qt5 ${pkgbranch} ${pkgfull}
 fi
 
+# remove symlink check
+# https://github.com/Homebrew/homebrew-core/blob/29bc842d5cdffde2917bce61a1d4eb742cf6d987/Formula/qt.rb#L133
+pushd $pkgsrc/${pkgfull}
+  git apply -v --directory qtbase ${DEVENVROOT}/var/patch/${pkgfull}.patch || true
+popd
+
 rm -rf $pkgsrc/${pkgfull}/build # clean up previous build
 mkdir -p $pkgsrc/${pkgfull}/build
 pushd $pkgsrc/${pkgfull}/build
@@ -48,9 +54,6 @@ pushd $pkgsrc/${pkgfull}/build
     fi
     perl init-repository -f
   fi
-
-  # disable symlink check
-  sed -i 's/qt_internal_check_if_path_has_symlinks("${CMAKE_BINARY_DIR}")/#qt_internal_check_if_path_has_symlinks("${CMAKE_BINARY_DIR}")/' $pkgsrc/${pkgfull}/qtbase/CMakeLists.txt
 
   cfgcmd=("cmake")
   cfgcmd+=("-DCMAKE_INSTALL_PREFIX=${DEVENVPREFIX}")

--- a/scripts/build.d/qt
+++ b/scripts/build.d/qt
@@ -20,10 +20,15 @@ if [ -z "${SYNCGIT}" ]; then
   download_md5 $pkgfn $pkgurl $pkgmd5
 
   mkdir -p $pkgsrc
-  pushd $pkgsrc > /dev/null
-   tar xf ${DEVENVDLROOT}/$pkgfn
-   mv $pkgfoler $pkgfull
-  popd
+  if [ -d $pkgsrc/$pkgfull ];
+  then
+    echo "$pkgfull already exist, skip extract"
+  else
+    pushd $pkgsrc > /dev/null
+    tar xf ${DEVENVDLROOT}/$pkgfn
+    mv $pkgfoler $pkgfull
+    popd
+  fi
 else
   pkgname=qt
   pkgbranch=${VERSION:-6.5.0}

--- a/scripts/build.d/qt
+++ b/scripts/build.d/qt
@@ -4,33 +4,38 @@ set -e
 
 if [ -z "${SYNCGIT}" ]; then
   pkgname=qt
-  pkgmajorver=${MAJOR_VER:-6.4}
-  pkgsubver=${SUB_VER:-1}
+  pkgmajorver=${MAJOR_VER:-6.5}
+  pkgsubver=${SUB_VER:-0}
   pkgver=$pkgmajorver.$pkgsubver
-  pkgmd5=${MD5:-ae18c8d4c2d0b8fb757c6881f6e273ea}
+  pkgmd5=${MD5:-10247444e4264ea9cee7d4a7c13efd34}
   pkgfull=$pkgname-$pkgver
   pkgfoler=qt-everywhere-src-$pkgver
 
   pkgfn=$pkgfull.tar.xz
   pkgurl=https://download.qt.io/official_releases/qt/$pkgmajorver/$pkgver/single/qt-everywhere-src-$pkgver.tar.xz
 
+  pkgsrc=${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src
+  #pkgsrc=/tmp
+
   download_md5 $pkgfn $pkgurl $pkgmd5
 
-  mkdir -p ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src
-  pushd ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src > /dev/null
-    tar Jxf ${DEVENVDLROOT}/$pkgfn
-    mv $pkgfoler $pkgfull
+  mkdir -p $pkgsrc
+  pushd $pkgsrc > /dev/null
+   tar xf ${DEVENVDLROOT}/$pkgfn
+   mv $pkgfoler $pkgfull
   popd
 else
   pkgname=qt
-  pkgbranch=${VERSION:-6.4.1}
+  pkgbranch=${VERSION:-6.5.0}
   pkgfull=$pkgname-$pkgbranch
   # qt5 is expected here, it seems qt did not change its repository name from qt5 to qt6
   # ref : https://wiki.qt.io/Building_Qt_6_from_Git#Getting_the_source_code
   syncgit git://code.qt.io/qt qt5 ${pkgbranch} ${pkgfull}
 fi
 
-pushd ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src/${pkgfull}
+rm -rf $pkgsrc/${pkgfull}/build # clean up previous build
+mkdir -p $pkgsrc/${pkgfull}/build
+pushd $pkgsrc/${pkgfull}/build
   if [ -n "${SYNCGIT}" ]; then
     if [[ -z "$(command -v perl)" ]]; then
        echo "perl not exist!"
@@ -39,14 +44,73 @@ pushd ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src/${pkgfull}
     perl init-repository -f
   fi
 
-  mkdir -p build
-  cd build
-  cmakecmd=("cmake")
-  cmakecmd+=("-DCMAKE_INSTALL_PREFIX=${DEVENVPREFIX}")
-  cmakecmd+=("../")
+  # disable symlink check
+  sed -i 's/qt_internal_check_if_path_has_symlinks("${CMAKE_BINARY_DIR}")/#qt_internal_check_if_path_has_symlinks("${CMAKE_BINARY_DIR}")/' $pkgsrc/${pkgfull}/qtbase/CMakeLists.txt
 
+  cfgcmd=("cmake")
+  cfgcmd+=("-DCMAKE_INSTALL_PREFIX=${DEVENVPREFIX}")
+  cfgcmd+=("-DCMAKE_BUILD_TYPE=Release")
+  #cfgcmd+=("-DCMAKE_BUILD_TYPE=Debug")
+  #cfgcmd+=("-DBUILD_qtimageformats=OFF")
+  #cfgcmd+=("-DBUILD_qtlanguageserver=OFF")
+  #cfgcmd+=("-DBUILD_qtsvg=OFF")
+  cfgcmd+=("-DBUILD_qtquicktimeline=OFF")
+  cfgcmd+=("-DBUILD_qtquick3d=OFF")
+  cfgcmd+=("-DBUILD_qt5compat=OFF")
+  cfgcmd+=("-DBUILD_qtactiveqt=OFF")
+  cfgcmd+=("-DBUILD_qtcharts=OFF")
+  cfgcmd+=("-DBUILD_qtcoap=OFF")
+  cfgcmd+=("-DBUILD_qtconnectivity=OFF")
+  cfgcmd+=("-DBUILD_qtdatavis3d=OFF")
+  cfgcmd+=("-DBUILD_qtwebsockets=OFF")
+  cfgcmd+=("-DBUILD_qthttpserver=OFF")
+  cfgcmd+=("-DBUILD_qttools=OFF")
+  cfgcmd+=("-DBUILD_qtdoc=OFF")
+  cfgcmd+=("-DBUILD_qtlottie=OFF")
+  cfgcmd+=("-DBUILD_qtmqtt=OFF")
+  cfgcmd+=("-DBUILD_qtnetworkauth=OFF")
+  cfgcmd+=("-DBUILD_qtopcua=OFF")
+  cfgcmd+=("-DBUILD_qtserialport=OFF")
+  cfgcmd+=("-DBUILD_qtlocation=OFF")
+  cfgcmd+=("-DBUILD_qtpositioning=OFF")
+  cfgcmd+=("-DBUILD_qtquick3dphysics=OFF")
+  cfgcmd+=("-DBUILD_qtremoteobjects=OFF")
+  cfgcmd+=("-DBUILD_qtscxml=OFF")
+  cfgcmd+=("-DBUILD_qtsensors=OFF")
+  cfgcmd+=("-DBUILD_qtserialbus=OFF")
+  cfgcmd+=("-DBUILD_qtspeech=OFF")
+  cfgcmd+=("-DBUILD_qttranslations=OFF")
+  cfgcmd+=("-DBUILD_qtvirtualkeyboard=OFF")
+  cfgcmd+=("-DBUILD_qtwayland=OFF")
+  cfgcmd+=("-DBUILD_qtwebchannel=OFF")
+  cfgcmd+=("-DBUILD_qtwebengine=OFF")
+  cfgcmd+=("-DBUILD_qtwebview=OFF")
+  cfgcmd+=("-DBUILD_qtquickeffectmaker=OFF")
+  cfgcmd+=("-DBUILD_qtgrpc=OFF")
+  cfgcmd+=("-DBUILD_qtmultimedia=OFF")
+  #cfgcmd+=("-DBUILD_qtdeclarative=OFF")
+  #cfgcmd+=("-DINPUT_xcb=yes")
+  #cfgcmd+=("-DINPUT_xcb_xlib=yes")
+  #cfgcmd+=("-DINPUT_bundled_xcb_xinput=yes")
+  #cfgcmd+=("-DINPUT_xkbcommon=yes")
+  #cfgcmd+=("-DINPUT_sessionmanager=yes")
+  cfgcmd+=("-DCMAKE_PREFIX_PATH=${DEVENVPREFIX}")
+  cfgcmd+=("-G Ninja")
+  cfgcmd+=("..")
+
+  cmakecmd=("cmake")
+  cmakecmd+=("--build")
+  cmakecmd+=(".")
+  cmakecmd+=("--parallel")
+
+  installcmd=("cmake")
+  installcmd+=("--install")
+  installcmd+=(".")
+
+  buildcmd configure.log "${cfgcmd[@]}"
   buildcmd cmake.log "${cmakecmd[@]}"
-  buildcmd make.log make install -j $NP
+  buildcmd install.log "${installcmd[@]}"
+
 popd
 
 # vim: set et nobomb ft=bash ff=unix fenc=utf8:

--- a/var/patch/qt-6.5.0.patch
+++ b/var/patch/qt-6.5.0.patch
@@ -1,0 +1,44 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -14,41 +14,6 @@ cmake_minimum_required(VERSION 3.16)
+ # Get the repo version and CMake policy details
+ include(.cmake.conf)
+ 
+-# Bail out if any part of the build directory's path is symlinked.
+-function(qt_internal_check_if_path_has_symlinks path)
+-    get_filename_component(dir "${path}" ABSOLUTE)
+-    set(is_symlink FALSE)
+-    if(CMAKE_HOST_WIN32)
+-        # CMake marks Windows mount points as symbolic links, so use simplified REALPATH check
+-        # on Windows platforms instead of IS_SYMLINK.
+-        get_filename_component(dir_realpath "${dir}" REALPATH)
+-        if(NOT dir STREQUAL dir_realpath)
+-            set(is_symlink TRUE)
+-        endif()
+-    else()
+-        while(TRUE)
+-            if(IS_SYMLINK "${dir}")
+-                set(is_symlink TRUE)
+-                break()
+-            endif()
+-
+-            set(prev_dir "${dir}")
+-            get_filename_component(dir "${dir}" DIRECTORY)
+-            if("${dir}" STREQUAL "${prev_dir}")
+-                return()
+-            endif()
+-        endwhile()
+-    endif()
+-    if(is_symlink)
+-        message(FATAL_ERROR "The path \"${path}\" contains symlinks. \
+-            This is not supported. Possible solutions:
+-            - map directories using a transparent mechanism such as mount --bind
+-            - pass the real path of the build directory to CMake, e.g. using \
+-            cd $(realpath <path>) before invoking cmake <source_dir>.")
+-    endif()
+-endfunction()
+-qt_internal_check_if_path_has_symlinks("${CMAKE_BINARY_DIR}")
+-
+ # Run auto detection routines, but not when doing standalone tests. In that case, the detection
+ # results are taken from either QtBuildInternals or the qt.toolchain.cmake file. Also, inhibit
+ # auto-detection in a top-level build, because the top-level project file already includes it.


### PR DESCRIPTION
I've added changes to the Qt build script:
1. bump version to `6.5.0 LTS`
2. add configure options before build
3. replace `make` to `ninja-build`
4. skip extraction if the source code is already extracted
5. add a patch file to remove symlink check