### PR TITLE
Update github actions macos version

### DIFF
--- a/.github/workflows/shunit2_runner.yml
+++ b/.github/workflows/shunit2_runner.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-10.15]
+        os: [ubuntu-20.04, macos-latest]
       fail-fast: false
     steps:
       - name: Checkout repository

--- a/.github/workflows/shunit2_runner.yml
+++ b/.github/workflows/shunit2_runner.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-latest]
+        os: [ubuntu-20.04, macos-12]
       fail-fast: false
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Since `macos-10-15` is outdated, therefore I have updated the macOS version of GitHub actions `Unittest - shunit2` from `macos-10-15` to `macos-latest`.