### PR TITLE
[add script] building modmesh env on twnia1

### DIFF
--- a/applications/modmesh/twnia1_env.sh
+++ b/applications/modmesh/twnia1_env.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+#PBS -P <PROJECTSYSTEMCODE>
+#PBS -N build_modmesh_env
+#PBS -l select=1:ncpus=8:mpiprocs=8
+#PBS -q <NODETYPE>
+#PBS -j oe
+
+# * this script is used to build the modmesh environment
+# it should work directly in login node, or you can submit it to the queue system
+# by using qsub command, for example:
+# qsub -v DEVENVFLAVOR=mmenv twnia1_env.sh
+# * you have to decide <PROJECTSYSTEMCODE>. check by command: get_su_balance
+# * you have to decide <NODETYPE> to other node type, e.g. cf160, ct160, etc.
+
+# * install devenv before running this script
+if [ -f ~/devenv/scripts/init ]; then source ~/devenv/scripts/init; fi
+
+module load gcc/11.2.0
+export CC=/pkg/gcc/11.2.0/bin/gcc
+export CXX=/pkg/gcc/11.2.0/bin/g++
+# * download LLVM before running this script, for twnia1:
+# https://download.qt.io/development_releases/prebuilt/libclang/libclang-release_120-based-linux-Rhel7.6-gcc5.3-x86_64.7z
+export LLVM_INSTALL_DIR=~/libclang120
+
+DEVENVFLAVOR=${DEVENVFLAVOR:-"mmenv"}
+echo "deleting old flavor: ${DEVENVFLAVOR}"
+devenv del ${DEVENVFLAVOR}
+devenv use ${DEVENVFLAVOR}
+
+export PKG_CONFIG_PATH="$(pkg-config --variable pc_path pkg-config)"
+export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:${DEVENVPREFIX}/lib64/pkgconfig
+export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:${DEVENVPREFIX}/lib/pkgconfig
+export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:${DEVENVPREFIX}/share/pkgconfig
+
+devenv build libffi
+
+devenv build xcb
+
+devenv build openssl
+
+CPPFLAGS=-I${DEVENVPREFIX}/lib/libffi-*/include devenv build python
+
+devenv build cmake
+
+pip3 cache purge
+
+pip3 install ninja meson
+
+devenv build libxkbcommon
+
+devenv build qt
+
+pip3 install numpy pytest flake8 matplotlib pybind11
+
+# required by pyside6
+pip3 install patchelf==0.15
+PYSIDE_BUILD=1 MAKESPEC=ninja VERSION=$(qmake -query QT_VERSION) devenv build pyside6

--- a/scripts/build.d/libffi
+++ b/scripts/build.d/libffi
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -e
+
+pkgname=libffi
+pkgver=${VERSION:-3.0.13}
+pkgfull=$pkgname-$pkgver
+pkgfn=$pkgfull.tar.gz
+pkgmd5=45f3b6dbc9ee7c7dfbbbc5feba571529
+pkgurl=https://src.fedoraproject.org/repo/pkgs/libffi/${pkgfn}/${pkgmd5}/${pkgfn}
+
+download_md5 $pkgfn $pkgurl $pkgmd5
+
+mkdir -p ${DEVENVCURRENTROOT}/src
+pushd ${DEVENVCURRENTROOT}/src > /dev/null
+  tar xf ${DEVENVDLROOT}/$pkgfn
+popd > /dev/null
+
+cfgcmd=("./configure")
+cfgcmd+=("--prefix=${DEVENVPREFIX}")
+
+pushd ${DEVENVCURRENTROOT}/src/${pkgfull} > /dev/null
+
+  buildcmd configure.log "${cfgcmd[@]}"
+  buildcmd make.log make -j ${NP}
+  buildcmd install.log make install
+
+popd > /dev/null
+
+# vim: set et nobomb ft=bash ff=unix fenc=utf8:

--- a/scripts/build.d/pyside6
+++ b/scripts/build.d/pyside6
@@ -53,7 +53,7 @@ fi
 
 PYTHON=${DEVENVPREFIX}/bin/python3
 
-LLVM_INSTALL_DIR=$(command -v llvm-config --prefix || echo "")
+LLVM_INSTALL_DIR=${LLVM_INSTALL_DIR:-$(command -v llvm-config --prefix)}
 if [ -z "${LLVM_INSTALL_DIR}" ] ; then
   # set LLVM_INSTALL_DIR to select the libclang installation for shiboken.
   # For example, a brew installed libclang may be specified with:
@@ -109,7 +109,8 @@ EOF
   # stage on Archlinux, therefore using GNU Make
   # instead of Ninja build to prevent OOM.
   if [ $(uname) == Linux ]; then
-    install_cmd+=("--make-spec=make")
+    MAKESPEC=${MAKESPEC:-make}
+    install_cmd+=("--make-spec=${MAKESPEC}")
     install_cmd+=("--parallel=${NP}")
   fi
 

--- a/scripts/build.d/python
+++ b/scripts/build.d/python
@@ -16,12 +16,12 @@ get_pip() {
 if [ "${SRCSYNC}" == "tarball" ] ; then
 
   pkgname=Python
-  pkgver=${VERSION:-3.11.1}
+  pkgver=${VERSION:-3.11.6}
   pkgfull=${pkgname}-${pkgver}
   pkgfn=${pkgfull}.tar.xz
   pkgurl=https://www.python.org/ftp/python/${pkgver}/${pkgfn}
 
-  download_md5 $pkgfn $pkgurl 4efe92adf28875c77d3b9b2e8d3bc44a
+  download_md5 $pkgfn $pkgurl d0c5a1a31efe879723e51addf56dd206
 
   mkdir -p ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src
   pushd ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src > /dev/null
@@ -57,7 +57,7 @@ pushd ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src/${pkgfull} > /dev/null
     sed -i -e "s/@OSX_ARCH@/${ARCH}/g" Lib/distutils/unixccompiler.py
   elif [ $(uname) == Linux ]; then
     export CPPFLAGS="-I${PREFIX}/include ${CPPFLAGS}"
-    export LDFLAGS="-L${PREFIX}/lib -Wl,-rpath=${PREFIX}/lib,--no-as-needed"
+    export LDFLAGS="-Wl,--no-as-needed -Wl,-rpath,${PREFIX}/lib -Wl,-rpath,${PREFIX}/lib64 -L${PREFIX}/lib -L${PREFIX}/lib64"
   fi
 
   cfgcmd=("./configure")

--- a/scripts/build.d/qt
+++ b/scripts/build.d/qt
@@ -112,6 +112,7 @@ pushd ${QTSRC}/${pkgfull}/build
   #cfgcmd+=("-DINPUT_bundled_xcb_xinput=yes")
   #cfgcmd+=("-DINPUT_xkbcommon=yes")
   #cfgcmd+=("-DINPUT_sessionmanager=yes")
+  cfgcmd+=("-DQT_ALLOW_SYMLINK_IN_PATHS=ON")
   cfgcmd+=("-DCMAKE_PREFIX_PATH=${DEVENVPREFIX}")
   cfgcmd+=("-G Ninja")
   cfgcmd+=("..")

--- a/scripts/build.d/qt
+++ b/scripts/build.d/qt
@@ -18,9 +18,9 @@ SKIPEXTRACT=${SKIPEXTRACT:-0}
 if [ -z "${SYNCGIT}" ]; then
   pkgname=qt
   pkgmajorver=${MAJOR_VER:-6.5}
-  pkgsubver=${SUB_VER:-0}
+  pkgsubver=${SUB_VER:-3}
   pkgver=$pkgmajorver.$pkgsubver
-  pkgmd5=${MD5:-10247444e4264ea9cee7d4a7c13efd34}
+  pkgmd5=${MD5:-755db0527410df135609b51defa1a689}
   pkgfull=$pkgname-$pkgver
   pkgfoler=qt-everywhere-src-$pkgver
 
@@ -41,7 +41,7 @@ if [ -z "${SYNCGIT}" ]; then
   fi
 else
   pkgname=qt
-  pkgbranch=${VERSION:-6.5.0}
+  pkgbranch=${VERSION:-6.5.3}
   pkgfull=$pkgname-$pkgbranch
   # qt5 is expected here, it seems qt did not change its repository name from qt5 to qt6
   # ref : https://wiki.qt.io/Building_Qt_6_from_Git#Getting_the_source_code

--- a/scripts/build.d/xcb
+++ b/scripts/build.d/xcb
@@ -40,12 +40,12 @@ pushd ${DEVENVCURRENTROOT}/src/${pkgfull} > /dev/null
 popd > /dev/null
 
 pkgname=util-macros
-pkgver=${VERSION:-1.20.0}
+pkgver=${VERSION:-1.18.0}
 pkgfull=$pkgname-$pkgver
 pkgfn=$pkgfull.tar.gz
 pkgurl=https://www.x.org/archive/individual/util/${pkgfn}
 
-download_md5 $pkgfn $pkgurl 7074a734224a9a953ca08cc0e62b91e3
+download_md5 $pkgfn $pkgurl fd0ba21b3179703c071bbb4c3e5fb0f4
 
 mkdir -p ${DEVENVCURRENTROOT}/src
 pushd ${DEVENVCURRENTROOT}/src > /dev/null


### PR DESCRIPTION
This is a prototype for https://github.com/solvcon/devenv/issues/153. Here is what I've done:

Add new scripts:
1. `applications/modmesh/twnia1_env.sh`
- A PBS script that sets up the building environment for modmesh on a compute node.
- It takes around 1 hour to complete the job, which equals (1 * ncpus) CPU hours.
Most of the time is spent being blocked at `ar`(archiver) due to slow disk I/O, and the most economical number of ncpus has not yet been determined.

2. `scripts/build.d/libffi`
- Compute node lacks `libffi-devel`.
- Version `3.0.13` was decided to match the version of the login node.
- Official release from GitHub starts from [`3.3 RC0`](https://github.com/libffi/libffi/releases)
so I use a package url from `fedoraproject.org`.

Revise some scripts:
1. `scripts/build.d/python`:
- Regular version update.
- Add `${PREFIX}/lib64` to `LDFLAGS` to let it able to find `libffi`
2. `scripts/build.d/pyside6`:
- Take `LLVM_INSTALL_DIR` from environment table if it is set.
- Add `MAKESPEC` to enable setting Ninja as the build tool.
3. `scripts/build.d/qt`:
- Regular version update.
4. `scripts/build.d/xcb`:
- Downgrade the version of `util-macros` from `1.20` to `1.18`. This is compatible with OS built-in `automake 1.13.4`,
so we won't need to build automake and pkg-config ourselves.