### PR TITLE
Fix use flavor cmd

### DIFF
--- a/scripts/init
+++ b/scripts/init
@@ -20,23 +20,22 @@ devenv() {
       ;;
     use)
       shift
-      # create subshell to isolate name space
-      (
-        . ${DEVENVROOT}/scripts/func.d/bash_utils
-        if [ ! -d "${DEVENVFLAVORROOT}/$1" ]; then
-          devenv_display "flavor $1 is not available"
-          return
+      if [ ! -d "${DEVENVFLAVORROOT}/$1" ]; then
+        # create subshell to isolate name space
+        (
+          . ${DEVENVROOT}/scripts/func.d/bash_utils
+            devenv_display -e "flavor $1 is not available"
+        )
+      else
+        # cmd use need to manipulate current session's env variables
+        # therefore subshell is not working here
+        if [ ! -z "${DEVENVFLAVOR}" ] ; then
+          devenv_act devenv_nameremove ${DEVENVFLAVOR}
         fi
-      )
-      # cmd use need to manipulate current session's env variables
-      # therefore subshell is not working here
-      if [ ! -z "${DEVENVFLAVOR}" ] ; then
-        devenv_act devenv_nameremove ${DEVENVFLAVOR}
+        devenv_act devenv_namemunge $1
+        export DEVENVCURRENTROOT=${DEVENVFLAVORROOT}/${DEVENVFLAVOR}
+        echo "now using '${DEVENVFLAVOR}'"
       fi
-
-      devenv_act devenv_namemunge $1
-      export DEVENVCURRENTROOT=${DEVENVFLAVORROOT}/${DEVENVFLAVOR}
-      echo "now using '${DEVENVFLAVOR}'"
       ;;
     off)
       # create subshell to isolate name space

--- a/tests/runner.sh
+++ b/tests/runner.sh
@@ -5,5 +5,6 @@ final_ret=0
 ./test_init_var.sh ; if [ $? != 0 ] ; then final_ret=1 ; fi
 ./test_bash_utils.sh ; if [ $? != 0 ] ; then final_ret=1 ; fi
 ./test_devenv_impl.sh ; if [ $? != 0 ] ; then final_ret=1 ; fi
+./test_init.sh ; if [ $? != 0 ] ; then final_ret=1 ; fi
 
 exit $final_ret

--- a/tests/test_init.sh
+++ b/tests/test_init.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+. ../scripts/init
+
+echo "*** test file: $(basename ${BASH_SOURCE[0]})"
+
+test_use_cmd() {
+  devenv add foo
+  devenv use foo
+  assertNotNull ${DEVENVFLAVOR}
+  devenv off
+  devenv del foo
+  devenv use foo
+  assertNull "${DEVENVFLAVOR}"
+}
+
+# Load and run shUnit2.
+. ./shunit2/shunit2

--- a/tests/test_init.sh
+++ b/tests/test_init.sh
@@ -6,11 +6,11 @@ echo "*** test file: $(basename ${BASH_SOURCE[0]})"
 test_use_cmd() {
   devenv add foo
   devenv use foo
-  assertNotNull ${DEVENVFLAVOR}
+  assertEquals ${DEVENVFLAVOR} "foo"
   devenv off
   devenv del foo
   devenv use foo
-  assertNull "${DEVENVFLAVOR}"
+  assertNotContains "${DEVENVFLAVOR}" "foo"
 }
 
 # Load and run shUnit2.


### PR DESCRIPTION
In this PR I fix a `use` command issue which is the `use` command will use an unavailable flavor. 
After:
```
$ devenv use foo ; echo $DEVENVFLAVOR
flavor foo is not available
```
Before:
```
$ devenv use foo ; echo $DEVENVFLAVOR
flavor foo is not available
now using 'foo'
foo
```