### PR TITLE
Advance pybind version to 2.12.0 and qt version to 6.6.3

### DIFF
--- a/scripts/build.d/pybind11
+++ b/scripts/build.d/pybind11
@@ -7,7 +7,7 @@ SRCSYNC=${SRCSYNC:-tarball}
 if [ "${SRCSYNC}" == "tarball" ] ; then
 
   pkgname=pybind11
-  pkgver=${VERSION:-2.10.2}
+  pkgver=${VERSION:-2.12.0}
   pkgfull=${pkgname}-${pkgver}
   pkgfn=${pkgfull}.tar.gz
   pkgurl=https://github.com/pybind/pybind11/archive/refs/tags/v${pkgver}.tar.gz

--- a/scripts/build.d/pybind11
+++ b/scripts/build.d/pybind11
@@ -12,7 +12,7 @@ if [ "${SRCSYNC}" == "tarball" ] ; then
   pkgfn=${pkgfull}.tar.gz
   pkgurl=https://github.com/pybind/pybind11/archive/refs/tags/v${pkgver}.tar.gz
 
-  download_md5 $pkgfn $pkgurl 695df9e99d92cdaa7fd0449fc5f30c26
+  download_md5 $pkgfn $pkgurl 891fb7337c45134f18a3eb4d7f6eca25
 
   mkdir -p ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src
   pushd ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src > /dev/null

--- a/scripts/build.d/qt
+++ b/scripts/build.d/qt
@@ -17,10 +17,10 @@ SKIPEXTRACT=${SKIPEXTRACT:-0}
 
 if [ -z "${SYNCGIT}" ]; then
   pkgname=qt
-  pkgmajorver=${MAJOR_VER:-6.5}
+  pkgmajorver=${MAJOR_VER:-6.6}
   pkgsubver=${SUB_VER:-3}
   pkgver=$pkgmajorver.$pkgsubver
-  pkgmd5=${MD5:-755db0527410df135609b51defa1a689}
+  pkgmd5=${MD5:-0e2c9dd87cbc6768da2bfc7f776c272f}
   pkgfull=$pkgname-$pkgver
   pkgfoler=qt-everywhere-src-$pkgver
 


### PR DESCRIPTION
1. Advance Qt version to 6.6.3 to match with the github workflow.
2. Advance pybind11 version to 2.12.0 to meet minimum requirement of modmesh.