### PR TITLE
Align Qt version

### DIFF
--- a/scripts/build.d/qt
+++ b/scripts/build.d/qt
@@ -41,7 +41,7 @@ if [ -z "${SYNCGIT}" ]; then
   fi
 else
   pkgname=qt
-  pkgbranch=${VERSION:-6.5.3}
+  pkgbranch=${VERSION:-6.8.1}
   pkgfull=$pkgname-$pkgbranch
   # qt5 is expected here, it seems qt did not change its repository name from qt5 to qt6
   # ref : https://wiki.qt.io/Building_Qt_6_from_Git#Getting_the_source_code


### PR DESCRIPTION
This PR updates the default Qt version in the build script to 6.6.3. Specifically, line 44 of the file scripts/build.d/qt was modified from: `pkgbranch=${VERSION:-6.5.3}` to `pkgbranch=${VERSION:-6.6.3}`. 

Please note that while this change updates the version reference, further testing for potential side effects of this update has not yet been conducted. I will perform testing once my new SSD arrives next week, as my current system is out of storage for building a virtual machine.

Related to #169 