### PR TITLE
upgrade Qt to 6.8.1 to sync with github workflow

### DIFF
--- a/.github/workflows/shunit2_runner.yml
+++ b/.github/workflows/shunit2_runner.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-latest]
+        os: [ubuntu-20.04, macos-13, macos-14, macos-15]
       fail-fast: false
     steps:
       - name: Checkout repository

--- a/.github/workflows/shunit2_runner.yml
+++ b/.github/workflows/shunit2_runner.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-13, macos-14, macos-15]
+        os: [ubuntu-20.04, macos-15]
       fail-fast: false
     steps:
       - name: Checkout repository

--- a/.github/workflows/shunit2_runner.yml
+++ b/.github/workflows/shunit2_runner.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-12]
+        os: [ubuntu-20.04, macos-latest]
       fail-fast: false
     steps:
       - name: Checkout repository

--- a/scripts/build.d/qt
+++ b/scripts/build.d/qt
@@ -17,10 +17,10 @@ SKIPEXTRACT=${SKIPEXTRACT:-0}
 
 if [ -z "${SYNCGIT}" ]; then
   pkgname=qt
-  pkgmajorver=${MAJOR_VER:-6.6}
-  pkgsubver=${SUB_VER:-3}
+  pkgmajorver=${MAJOR_VER:-6.8}
+  pkgsubver=${SUB_VER:-1}
   pkgver=$pkgmajorver.$pkgsubver
-  pkgmd5=${MD5:-0e2c9dd87cbc6768da2bfc7f776c272f}
+  pkgmd5=${MD5:--4068b07ca6366bcb9ba56508bbbf20e6}
   pkgfull=$pkgname-$pkgver
   pkgfoler=qt-everywhere-src-$pkgver
 


### PR DESCRIPTION
This PR is to address issue #171 . The Qt version in the build script is upgraded to 6.8.1 in alignment with GitHub workflow in modmesh. 