### PR TITLE
Update build scripts for Python 3.13

### DIFF
--- a/scripts/build.d/cython
+++ b/scripts/build.d/cython
@@ -6,13 +6,14 @@ SRCSYNC=${SRCSYNC:-tarball}
 
 if [ "${SRCSYNC}" == "tarball" ] ; then
 
+  # Tarball location: https://github.com/cython/cython/releases
   pkgname=Cython
-  pkgver=${VERSION:-0.29.32}
+  pkgver=${VERSION:-3.0.12}
   pkgfull=${pkgname}-${pkgver}
   pkgfn=${pkgfull}.tar.gz
-  pkgurl=https://files.pythonhosted.org/packages/4c/76/1e41fbb365ad20b6efab2e61b0f4751518444c953b390f9b2d36cf97eea0/${pkgfn}
+  pkgurl=https://github.com/cython/cython/archive/refs/tags/${pkgver}.tar.gz
 
-  download_md5 $pkgfn $pkgurl 91c36ea86c00adcc5c1c11cf48b733c0
+  download_md5 $pkgfn $pkgurl 194658f8ae1ae8804f864d4e147fddf6
 
   mkdir -p ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src
   pushd ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src
@@ -33,6 +34,13 @@ else
   devenv_display -e "Invalid \${SRCSYNC} ${SRCSYNC}"
   exit
 
+fi
+
+if [ "${DEVENV_DLONLY}" == "1" ] ; then
+  echo "\${DEVENV_DLONLY}=1 ; existing"
+  exit 1
+else
+  echo "if you want to exit after downloading: export \${DEVENV_DLONLY}=1"
 fi
 
 # build.

--- a/scripts/build.d/matplotlib
+++ b/scripts/build.d/matplotlib
@@ -1,22 +1,22 @@
 #!/usr/bin/env bash
 
-# Building document: https://numpy.org/doc/stable/building/index.html
+# This script is work in progress
 
 set -e
 
 SRCSYNC=${SRCSYNC:-tarball}
 
-pkgname=numpy
+pkgname=matplotlib
 
 if [ "${SRCSYNC}" == "tarball" ] ; then
 
-  # Tarball location: https://github.com/numpy/numpy/releases
-  pkgver=${VERSION:-2.2.4}
+  # Tarball location: https://github.com/matplotlib/matplotlib/releases
+  pkgver=${VERSION:-3.10.1}
   pkgfull=${pkgname}-${pkgver}
   pkgfn=${pkgfull}.tar.gz
-  pkgurl=https://github.com/${pkgname}/${pkgname}/releases/download/v${pkgver}/${pkgfn}
+  pkgurl=https://github.com/${pkgname}/${pkgname}/archive/refs/tags/v${pkgver}.tar.gz
 
-  download_md5 $pkgfn $pkgurl 56232f4a69b03dd7a87a55fffc5f2ebc
+  download_md5 $pkgfn $pkgurl 515fc1544d7617b38fe5a9328538047b
 
   mkdir -p ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src
   pushd ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src > /dev/null
@@ -65,44 +65,18 @@ PYTHON=${DEVENVPREFIX}/bin/python3
 rm -f site.cfg
 
 if [ $(uname) == Darwin ] ; then
-  NPY_BLAS_ORDER=Accelerate
-  echo "Darwin"
-  cat >> site.cfg << EOF
-[accelerate]
-libraries = Accelerate, vecLib
-EOF
-elif [ $(uname) == Linux ] ; then
-  BLAS=${BLAS:-mkl}
-  if [ ${BLAS} == mkl ] ; then
-    NPY_BLAS_ORDER=MKL
-  else
-    NPY_BLAS_ORDER=openblas
-  cat >> site.cfg << EOF
-[openblas]
-libraries = openblas
-library_dirs = ${DEVENVPREFIX}/lib:/usr/local/lib:/usr/lib
-include_dirs = ${DEVENVPREFIX}/include/openblas:/usr/local/include/openblas:/usr/include/openblas
-runtime_library_dirs = ${DEVENVPREFIX}/lib
-EOF
-  fi
+  # SciPy does not yet support accelerate on macos
+  openblaspath="/opt/homebrew/opt/openblas"
+  export PKG_CONFIG_PATH="${openblaspath}/lib/pkgconfig"
+  # Xcode clang does not support -fopenmp
+  llvmpath="/opt/homebrew/opt/llvm"
+  export CC="${llvmpath}/bin/clang"
+  export CXX="${llvmpath}/bin/clang++"
+  export LDFLAGS="-L${llvmpath}/lib"
+  export CPPFLAGS="-I${llvmpath}/include"
 fi
 
 export NPY_BLAS_ORDER
-
-rm -f setup.cfg
-cat >> setup.cfg << EOF
-# See the docstring in versioneer.py for instructions. Note that you must
-# re-run 'versioneer.py setup' after changing this section, and commit the
-# resulting files.
-
-[versioneer]
-VCS = git
-style = pep440
-versionfile_source = numpy/_version.py
-versionfile_build = numpy/_version.py
-tag_prefix = v
-parentdir_prefix = numpy-
-EOF
 
 if [ -z "${NOFORTRAN}" ] ; then
 cat >> setup.cfg << EOF
@@ -112,16 +86,12 @@ fcompiler = gfortran
 EOF
 fi
 
-buildcmd dependency.log pip3 install -r requirements/build_requirements.txt
-buildcmd build.log spin build -j ${NP}
+buildcmd dependency.log pip3 install -r requirements/dev.txt
+buildcmd build.log ${PYTHON} dev.py build -j ${NP}
 buildcmd install.log pip3 install .
-# Use -e . --no-build-isolation when hacking numpy
+# Use -e . --no-build-isolation when hacking matplotlib
 #buildcmd install.log pip3 install -e . --no-build-isolation
 
 popd > /dev/null
-
-# Check lapack version.
-echo "Check lapack version ..."
-${PYTHON} -c "import numpy as np ; np.show_config()"
 
 # vim: set et nobomb ft=bash ff=unix fenc=utf8:

--- a/scripts/build.d/pybind11
+++ b/scripts/build.d/pybind11
@@ -7,12 +7,12 @@ SRCSYNC=${SRCSYNC:-tarball}
 if [ "${SRCSYNC}" == "tarball" ] ; then
 
   pkgname=pybind11
-  pkgver=${VERSION:-2.12.0}
+  pkgver=${VERSION:-2.13.6}
   pkgfull=${pkgname}-${pkgver}
   pkgfn=${pkgfull}.tar.gz
   pkgurl=https://github.com/pybind/pybind11/archive/refs/tags/v${pkgver}.tar.gz
 
-  download_md5 $pkgfn $pkgurl 891fb7337c45134f18a3eb4d7f6eca25
+  download_md5 $pkgfn $pkgurl a04dead9c83edae6d84e2e343da7feeb
 
   mkdir -p ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src
   pushd ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src > /dev/null
@@ -33,6 +33,13 @@ else
   devenv_display -e "Invalid \${SRCSYNC} ${SRCSYNC}"
   exit
 
+fi
+
+if [ "${DEVENV_DLONLY}" == "1" ] ; then
+  echo "\${DEVENV_DLONLY}=1 ; existing"
+  exit 1
+else
+  echo "if you want to exit after downloading: export \${DEVENV_DLONLY}=1"
 fi
 
 # build.

--- a/scripts/build.d/pyside6
+++ b/scripts/build.d/pyside6
@@ -26,8 +26,9 @@ if [ "${SRCSYNC}" == "tarball" ] ; then
 
 elif [ "${SRCSYNC}" == "git" ] ; then
 
+  # PySide repository: https://code.qt.io/cgit/pyside/pyside-setup.git/
   pkgname=pyside-setup
-  pkgbranch=${VERSION:-dev}
+  pkgbranch=${VERSION:-v6.8.1}
   pkgfull=$pkgname
 
   # unpack (clone)
@@ -38,6 +39,13 @@ else
   devenv_display -e "Invalid \${SRCSYNC} ${SRCSYNC}"
   exit
 
+fi
+
+if [ "${DEVENV_DLONLY}" == "1" ] ; then
+  echo "\${DEVENV_DLONLY}=1 ; existing"
+  exit 1
+else
+  echo "if you want to exit after downloading: export \${DEVENV_DLONLY}=1"
 fi
 
 # build.
@@ -105,18 +113,21 @@ EOF
   install_cmd+=("setup.py")
   install_cmd+=("install")
 
+  install_cmd+=("--qtpaths=${QTPATHS}")
+  install_cmd+=("--ignore-git")
+  install_cmd+=("--no-qt-tools")
+  install_cmd+=("--parallel=${NP}")
+  if [ "${PYSIDE_REUSE_BUILD}" == "1" ] ; then
+    install_cmd+=("--reuse-build")
+  fi
+
   # Ninja build will casue OOM during install
   # stage on Archlinux, therefore using GNU Make
   # instead of Ninja build to prevent OOM.
   if [ $(uname) == Linux ]; then
     MAKESPEC=${MAKESPEC:-make}
     install_cmd+=("--make-spec=${MAKESPEC}")
-    install_cmd+=("--parallel=${NP}")
   fi
-
-  install_cmd+=("--qtpaths=${QTPATHS}")
-  install_cmd+=("--ignore-git")
-  install_cmd+=("--reuse-build")
 
   buildcmd install.log "${install_cmd[@]}"
 popd > /dev/null

--- a/scripts/build.d/python
+++ b/scripts/build.d/python
@@ -16,12 +16,12 @@ get_pip() {
 if [ "${SRCSYNC}" == "tarball" ] ; then
 
   pkgname=Python
-  pkgver=${VERSION:-3.11.6}
+  pkgver=${VERSION:-3.13.2}
   pkgfull=${pkgname}-${pkgver}
   pkgfn=${pkgfull}.tar.xz
   pkgurl=https://www.python.org/ftp/python/${pkgver}/${pkgfn}
 
-  download_md5 $pkgfn $pkgurl d0c5a1a31efe879723e51addf56dd206
+  download_md5 $pkgfn $pkgurl 4c2d9202ab4db02c9d0999b14655dfe5
 
   mkdir -p ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src
   pushd ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src > /dev/null
@@ -44,6 +44,13 @@ else
 
 fi
 
+if [ "${DEVENV_DLONLY}" == "1" ] ; then
+  echo "\${DEVENV_DLONLY}=1 ; existing"
+  exit 1
+else
+  echo "if you want to exit after downloading: export \${DEVENV_DLONLY}=1"
+fi
+
 # build.
 
 pushd ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src/${pkgfull} > /dev/null
@@ -54,7 +61,6 @@ pushd ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src/${pkgfull} > /dev/null
   if [ $(uname) == Darwin ]; then
     export CPPFLAGS="-I${PREFIX}/include ${CPPFLAGS}"
     export LDFLAGS="-Wl,-rpath,${PREFIX}/lib -L${PREFIX}/lib ${LDFLAGS}"
-    sed -i -e "s/@OSX_ARCH@/${ARCH}/g" Lib/distutils/unixccompiler.py
   elif [ $(uname) == Linux ]; then
     export CPPFLAGS="-I${PREFIX}/include ${CPPFLAGS}"
     export LDFLAGS="-Wl,--no-as-needed -Wl,-rpath,${PREFIX}/lib -Wl,-rpath,${PREFIX}/lib64 -L${PREFIX}/lib -L${PREFIX}/lib64"

--- a/scripts/build.d/qt
+++ b/scripts/build.d/qt
@@ -20,7 +20,7 @@ if [ -z "${SYNCGIT}" ]; then
   pkgmajorver=${MAJOR_VER:-6.8}
   pkgsubver=${SUB_VER:-1}
   pkgver=$pkgmajorver.$pkgsubver
-  pkgmd5=${MD5:--4068b07ca6366bcb9ba56508bbbf20e6}
+  pkgmd5=${MD5:-4068b07ca6366bcb9ba56508bbbf20e6}
   pkgfull=$pkgname-$pkgver
   pkgfoler=qt-everywhere-src-$pkgver
 
@@ -30,13 +30,14 @@ if [ -z "${SYNCGIT}" ]; then
   download_md5 $pkgfn $pkgurl $pkgmd5
 
   mkdir -p ${QTSRC}
-  if [ -d ${QTSRC}/$pkgfull ] && [ ${SKIPEXTRACT} -eq 1 ];
-  then
+  if [ -d ${QTSRC}/$pkgfull ] || [ ${SKIPEXTRACT} -eq 1 ]; then
     echo "QTSRC: ${QTSRC}/$pkgfull already exist, skip extract"
   else
     pushd ${QTSRC} > /dev/null
-    tar xf ${DEVENVDLROOT}/$pkgfn
-    mv $pkgfoler $pkgfull
+      echo "QTSRC: ${QTSRC}/$pkgfull extracting ..."
+      tar xf ${DEVENVDLROOT}/$pkgfn
+      mv $pkgfoler $pkgfull
+      echo "QTSRC: ${QTSRC}/$pkgfull extracted"
     popd
   fi
 else
@@ -48,13 +49,30 @@ else
   syncgit git://code.qt.io/qt qt5 ${pkgbranch} ${pkgfull}
 fi
 
+if [ "${DEVENV_DLONLY}" == "1" ] ; then
+  echo "\${DEVENV_DLONLY}=1 ; existing"
+  exit 1
+else
+  echo "if you want to exit after downloading: export \${DEVENV_DLONLY}=1"
+fi
+
 # remove symlink check
 # https://github.com/Homebrew/homebrew-core/blob/29bc842d5cdffde2917bce61a1d4eb742cf6d987/Formula/qt.rb#L133
 pushd ${QTSRC}/${pkgfull}
   git apply -v --directory qtbase ${DEVENVROOT}/var/patch/${pkgfull}.patch || true
 popd
 
-rm -rf ${QTSRC}/${pkgfull}/build # clean up previous build
+# build.
+
+if [ "${DVQT_NOCLEAN}" != "1" ] ; then
+  echo "Cleaning up build directory ${QTSRC}/${pkgfull}/build ..."
+  echo "Set \$DVQT_NOCLEAN=1 to skip cleaning up"
+  rm -rf ${QTSRC}/${pkgfull}/build # clean up previous build
+  echo "Cleaned up build directory ${QTSRC}/${pkgfull}/build"
+else
+  echo "No cleaning up build directory ${QTSRC}/${pkgfull}/build"
+fi
+
 mkdir -p ${QTSRC}/${pkgfull}/build
 pushd ${QTSRC}/${pkgfull}/build
   if [ -n "${SYNCGIT}" ]; then
@@ -73,7 +91,8 @@ pushd ${QTSRC}/${pkgfull}/build
   #cfgcmd+=("-DBUILD_qtlanguageserver=OFF")
   #cfgcmd+=("-DBUILD_qtsvg=OFF")
   cfgcmd+=("-DBUILD_qtquicktimeline=OFF")
-  #cfgcmd+=("-DBUILD_qtquick3d=OFF")
+  cfgcmd+=("-DBUILD_qtquick3d=OFF")  # I cannot get it built on macos 15.4 and Xcode 16.3
+  cfgcmd+=("-DBUILD_qtgraphs=OFF")  # depends on qtquick3d
   cfgcmd+=("-DBUILD_qt5compat=OFF")
   cfgcmd+=("-DBUILD_qtactiveqt=OFF")
   cfgcmd+=("-DBUILD_qtcharts=OFF")
@@ -126,9 +145,15 @@ pushd ${QTSRC}/${pkgfull}/build
   installcmd+=("--install")
   installcmd+=(".")
 
-  buildcmd configure.log "${cfgcmd[@]}"
-  buildcmd cmake.log "${cmakecmd[@]}"
-  buildcmd install.log "${installcmd[@]}"
+  if [ "${DVQT_NOCONFIG}" != "1" ] ; then
+    buildcmd configure.log "${cfgcmd[@]}"
+  fi
+  if [ "${DVQT_NOBUILD}" != "1" ] ; then
+    buildcmd build.log "${cmakecmd[@]}"
+  fi
+  if [ "${DVQT_NOINSTALL}" != "1" ] ; then
+    buildcmd install.log "${installcmd[@]}"
+  fi
 
 popd
 

--- a/scripts/build.d/scipy
+++ b/scripts/build.d/scipy
@@ -1,22 +1,22 @@
 #!/usr/bin/env bash
 
-# Building document: https://numpy.org/doc/stable/building/index.html
+# Building document: https://docs.scipy.org/doc/scipy/building/index.html
 
 set -e
 
 SRCSYNC=${SRCSYNC:-tarball}
 
-pkgname=numpy
+pkgname=scipy
 
 if [ "${SRCSYNC}" == "tarball" ] ; then
 
-  # Tarball location: https://github.com/numpy/numpy/releases
-  pkgver=${VERSION:-2.2.4}
+  # Tarball location: https://github.com/scipy/scipy/releases
+  pkgver=${VERSION:-1.15.2}
   pkgfull=${pkgname}-${pkgver}
   pkgfn=${pkgfull}.tar.gz
   pkgurl=https://github.com/${pkgname}/${pkgname}/releases/download/v${pkgver}/${pkgfn}
 
-  download_md5 $pkgfn $pkgurl 56232f4a69b03dd7a87a55fffc5f2ebc
+  download_md5 $pkgfn $pkgurl 515fc1544d7617b38fe5a9328538047b
 
   mkdir -p ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src
   pushd ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src > /dev/null
@@ -65,44 +65,18 @@ PYTHON=${DEVENVPREFIX}/bin/python3
 rm -f site.cfg
 
 if [ $(uname) == Darwin ] ; then
-  NPY_BLAS_ORDER=Accelerate
-  echo "Darwin"
-  cat >> site.cfg << EOF
-[accelerate]
-libraries = Accelerate, vecLib
-EOF
-elif [ $(uname) == Linux ] ; then
-  BLAS=${BLAS:-mkl}
-  if [ ${BLAS} == mkl ] ; then
-    NPY_BLAS_ORDER=MKL
-  else
-    NPY_BLAS_ORDER=openblas
-  cat >> site.cfg << EOF
-[openblas]
-libraries = openblas
-library_dirs = ${DEVENVPREFIX}/lib:/usr/local/lib:/usr/lib
-include_dirs = ${DEVENVPREFIX}/include/openblas:/usr/local/include/openblas:/usr/include/openblas
-runtime_library_dirs = ${DEVENVPREFIX}/lib
-EOF
-  fi
+  # SciPy does not yet support accelerate on macos
+  openblaspath="/opt/homebrew/opt/openblas"
+  export PKG_CONFIG_PATH="${openblaspath}/lib/pkgconfig"
+  # Xcode clang does not support -fopenmp
+  llvmpath="/opt/homebrew/opt/llvm"
+  export CC="${llvmpath}/bin/clang"
+  export CXX="${llvmpath}/bin/clang++"
+  export LDFLAGS="-L${llvmpath}/lib"
+  export CPPFLAGS="-I${llvmpath}/include"
 fi
 
 export NPY_BLAS_ORDER
-
-rm -f setup.cfg
-cat >> setup.cfg << EOF
-# See the docstring in versioneer.py for instructions. Note that you must
-# re-run 'versioneer.py setup' after changing this section, and commit the
-# resulting files.
-
-[versioneer]
-VCS = git
-style = pep440
-versionfile_source = numpy/_version.py
-versionfile_build = numpy/_version.py
-tag_prefix = v
-parentdir_prefix = numpy-
-EOF
 
 if [ -z "${NOFORTRAN}" ] ; then
 cat >> setup.cfg << EOF
@@ -112,16 +86,12 @@ fcompiler = gfortran
 EOF
 fi
 
-buildcmd dependency.log pip3 install -r requirements/build_requirements.txt
-buildcmd build.log spin build -j ${NP}
+buildcmd dependency.log pip3 install -r requirements/dev.txt
+buildcmd build.log ${PYTHON} dev.py build -j ${NP}
 buildcmd install.log pip3 install .
-# Use -e . --no-build-isolation when hacking numpy
+# Use -e . --no-build-isolation when hacking scipy
 #buildcmd install.log pip3 install -e . --no-build-isolation
 
 popd > /dev/null
-
-# Check lapack version.
-echo "Check lapack version ..."
-${PYTHON} -c "import numpy as np ; np.show_config()"
 
 # vim: set et nobomb ft=bash ff=unix fenc=utf8:

--- a/scripts/build.d/zlib
+++ b/scripts/build.d/zlib
@@ -7,11 +7,11 @@ SRCSYNC=${SRCSYNC:-tarball}
 if [ "${SRCSYNC}" == "tarball" ]; then
 
   pkgname=zlib
-  pkgver=${VERSION:-v1.2.13}
+  pkgver=${VERSION:-v1.3.1}
   pkgfull=${pkgname}-${pkgver:1}
   pkgfn=${pkgfull}.tar.gz
   pkgurl=https://github.com/madler/zlib/archive/refs/tags/${pkgver}.tar.gz
-  download_md5 ${pkgfn} ${pkgurl} 9c7d356c5acaa563555490676ca14d23
+  download_md5 ${pkgfn} ${pkgurl} ddb17dbbf2178807384e57ba0d81e6a1
 
   mkdir -p ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src
   pushd ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src > /dev/null
@@ -31,6 +31,13 @@ else
   devenv_display -e "Invalid \${SRCSYNC} ${SRCSYNC}"
   exit
 
+fi
+
+if [ "${DEVENV_DLONLY}" == "1" ] ; then
+  echo "\${DEVENV_DLONLY}=1 ; existing"
+  exit 1
+else
+  echo "if you want to exit after downloading: export \${DEVENV_DLONLY}=1"
 fi
 
 pushd ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src/${pkgfull} > /dev/null

--- a/scripts/func.d/build_utils
+++ b/scripts/func.d/build_utils
@@ -13,14 +13,16 @@ download_md5 () {
   elif [ $(uname) == Linux ] ; then
     local md5=md5sum
   fi
-  if [ ! -e $loc ] || [ $md5hash != `$md5 $loc | cut -d ' ' -f 1` ] ; then
+  local md5hash_calc=$($md5 $loc | cut -d ' ' -f 1)
+  echo "$(basename $loc) md5 $md5hash (archived)"
+  echo "$(basename $loc) md5 $md5hash_calc (calculated)"
+  if [ ! -e $loc ] || [ "$md5hash" != "$md5hash_calc" ] ; then
     mkdir -p $(dirname $loc)
     rm -f $loc
     echo "Download from $url"
     curl -sSL ${CURLARGS} -o $loc $url
   fi
-  local md5hash_calc=`$md5 $loc | cut -d ' ' -f 1`
-  if [ $md5hash != $md5hash_calc ] ; then
+  if [ "$md5hash" != "$md5hash_calc" ] ; then
     echo "$(basename $loc) md5 hash $md5hash but got $md5hash_calc"
   else
     echo "$(basename $loc) md5 hash $md5hash confirmed"


### PR DESCRIPTION
* Cython version bumps from 0.29.32 to 3.0.12
* matplotlib adds WIP build script
* numpy version bumps from 1.24.1 to 2.2.4
* pybind11 version bumps from 2.12.0 to 2.13.6
* PySide6 version bumps (and fix) to v.6.8.1
* Python version bumps from 3.11.6 to 3.13.2
* Qt fixes archived hash
* SciPy adds build script
* zlib version bumps from 1.2.13 to 1.3.1
* Add DEVENV_DLONLY env variable for the updated build scripts
* print more hash messages in the download_md5() shell function