### PR TITLE
Fix: Switch CMake version to 4.0.1

### DIFF
--- a/scripts/build.d/cmake
+++ b/scripts/build.d/cmake
@@ -13,7 +13,7 @@ if [ "${SRCSYNC}" == "tarball" ] ; then
   pkgfn=${pkgfull}.tar.gz
   pkgurl=https://github.com/Kitware/CMake/releases/download/v${pkgver}/${pkgfn}
 
-  download_md5 $pkgfn $pkgurl db659ed92a8fcc880f95b492bde2eb44
+  download_md5 $pkgfn $pkgurl 534b4af60e0b4b3fa43199d75d2debef
 
   mkdir -p ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src
   pushd ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src > /dev/null

--- a/scripts/build.d/cmake
+++ b/scripts/build.d/cmake
@@ -8,7 +8,7 @@ pkgname=cmake
 
 if [ "${SRCSYNC}" == "tarball" ] ; then
 
-  pkgver=${VERSION:-3.28.1}
+  pkgver=${VERSION:-4.0.1}
   pkgfull=${pkgname}-${pkgver}
   pkgfn=${pkgfull}.tar.gz
   pkgurl=https://github.com/Kitware/CMake/releases/download/v${pkgver}/${pkgfn}


### PR DESCRIPTION
# Description

Unable to build CMake ver. 3.28.1, as multiple errors occurred during the build process.

The error messages:

```bash
/Library/Developer/CommandLineTools/SDKs/MacOSX15.4.sdk/usr/include/_stdio.h:318:7: error: expected identifier or '('
  318 | FILE    *fdopen(int, const char *) __DARWIN_ALIAS_STARTING(__MAC_10_6, __IPHONE_2_0, __DARWIN_ALIAS(fdopen));
      |          ^
/Users/tingweilin/devenv/flavors/prime/src/cmake-3.28.1/Utilities/cmzlib/zutil.h:147:33: note: expanded from macro 'fdopen'
  147 | #        define fdopen(fd,mode) NULL /* No fdopen() */
      |                                 ^
/Library/Developer/CommandLineTools/usr/lib/clang/17/include/__stddef_null.h:26:16: note: expanded from macro 'NULL'
   26 | #define NULL ((void*)0)
      |                ^
In file included from /Users/tingweilin/devenv/flavors/prime/src/cmake-3.28.1/Utilities/cmzlib/zutil.c:10:
In file included from /Users/tingweilin/devenv/flavors/prime/src/cmake-3.28.1/Utilities/cmzlib/gzguts.h:21:
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX15.4.sdk/usr/include/stdio.h:61:
/Library/Developer/CommandLineTools/SDKs/MacOSX15.4.sdk/usr/include/_stdio.h:318:7: error: expected ')'
/Users/tingweilin/devenv/flavors/prime/src/cmake-3.28.1/Utilities/cmzlib/zutil.h:147:33: note: expanded from macro 'fdopen'
  147 | #        define fdopen(fd,mode) NULL /* No fdopen() */
      |                                 ^
/Library/Developer/CommandLineTools/usr/lib/clang/17/include/__stddef_null.h:26:16: note: expanded from macro 'NULL'
   26 | #define NULL ((void*)0)
      |                ^
/Library/Developer/CommandLineTools/SDKs/MacOSX15.4.sdk/usr/include/_stdio.h:318:7: note: to match this '('
/Users/tingweilin/devenv/flavors/prime/src/cmake-3.28.1/Utilities/cmzlib/zutil.h:147:33: note: expanded from macro 'fdopen'
  147 | #        define fdopen(fd,mode) NULL /* No fdopen() */
      |                                 ^
/Library/Developer/CommandLineTools/usr/lib/clang/17/include/__stddef_null.h:26:15: note: expanded from macro 'NULL'
   26 | #define NULL ((void*)0)
      |               ^
In file included from /Users/tingweilin/devenv/flavors/prime/src/cmake-3.28.1/Utilities/cmzlib/zutil.c:10:
In file included from /Users/tingweilin/devenv/flavors/prime/src/cmake-3.28.1/Utilities/cmzlib/gzguts.h:21:
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX15.4.sdk/usr/include/stdio.h:61:
/Library/Developer/CommandLineTools/SDKs/MacOSX15.4.sdk/usr/include/_stdio.h:318:7: error: expected ')'
  318 | FILE    *fdopen(int, const char *) __DARWIN_ALIAS_STARTING(__MAC_10_6, __IPHONE_2_0, __DARWIN_ALIAS(fdopen));
      |          ^
/Users/tingweilin/devenv/flavors/prime/src/cmake-3.28.1/Utilities/cmzlib/zutil.h:147:33: note: expanded from macro 'fdopen'
  147 | #        define fdopen(fd,mode) NULL /* No fdopen() */
      |                                 ^
/Library/Developer/CommandLineTools/usr/lib/clang/17/include/__stddef_null.h:26:22: note: expanded from macro 'NULL'
   26 | #define NULL ((void*)0)
      |                      ^
/Library/Developer/CommandLineTools/SDKs/MacOSX15.4.sdk/usr/include/_stdio.h:318:7: note: to match this '('
/Users/tingweilin/devenv/flavors/prime/src/cmake-3.28.1/Utilities/cmzlib/zutil.h:147:33: note: expanded from macro 'fdopen'
  147 | #        define fdopen(fd,mode) NULL /* No fdopen() */
      |                                 ^
/Library/Developer/CommandLineTools/usr/lib/clang/17/include/__stddef_null.h:26:14: note: expanded from macro 'NULL'
   26 | #define NULL ((void*)0)
      |              ^
3 errors generated.
make[2]: *** [Utilities/cmzlib/CMakeFiles/cmzlib.dir/zutil.c.o] Error 1
make[1]: *** [Utilities/cmzlib/CMakeFiles/cmzlib.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....

...

/Library/Developer/CommandLineTools/SDKs/MacOSX15.4.sdk/usr/include/_stdio.h:318:7: error: expected identifier or '('
  318 | FILE    *fdopen(int, const char *) __DARWIN_ALIAS_STARTING(__MAC_10_6, __IPHONE_2_0, __DARWIN_ALIAS(fdopen));
      |          ^
/Users/tingweilin/devenv/flavors/prime/src/cmake-3.28.1/Utilities/cmzlib/zutil.h:147:33: note: expanded from macro 'fdopen'
  147 | #        define fdopen(fd,mode) NULL /* No fdopen() */
      |                                 ^
/Library/Developer/CommandLineTools/usr/lib/clang/17/include/__stddef_null.h:26:16: note: expanded from macro 'NULL'
   26 | #define NULL ((void*)0)
      |                ^
In file included from /Users/tingweilin/devenv/flavors/prime/src/cmake-3.28.1/Utilities/cmzlib/zutil.c:10:
In file included from /Users/tingweilin/devenv/flavors/prime/src/cmake-3.28.1/Utilities/cmzlib/gzguts.h:21:
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX15.4.sdk/usr/include/stdio.h:61:
/Library/Developer/CommandLineTools/SDKs/MacOSX15.4.sdk/usr/include/_stdio.h:318:7: error: expected ')'
/Users/tingweilin/devenv/flavors/prime/src/cmake-3.28.1/Utilities/cmzlib/zutil.h:147:33: note: expanded from macro 'fdopen'
  147 | #        define fdopen(fd,mode) NULL /* No fdopen() */
      |                                 ^
/Library/Developer/CommandLineTools/usr/lib/clang/17/include/__stddef_null.h:26:16: note: expanded from macro 'NULL'
   26 | #define NULL ((void*)0)
      |                ^
/Library/Developer/CommandLineTools/SDKs/MacOSX15.4.sdk/usr/include/_stdio.h:318:7: note: to match this '('
/Users/tingweilin/devenv/flavors/prime/src/cmake-3.28.1/Utilities/cmzlib/zutil.h:147:33: note: expanded from macro 'fdopen'
  147 | #        define fdopen(fd,mode) NULL /* No fdopen() */
      |                                 ^
/Library/Developer/CommandLineTools/usr/lib/clang/17/include/__stddef_null.h:26:15: note: expanded from macro 'NULL'
   26 | #define NULL ((void*)0)
      |               ^
In file included from /Users/tingweilin/devenv/flavors/prime/src/cmake-3.28.1/Utilities/cmzlib/zutil.c:10:
In file included from /Users/tingweilin/devenv/flavors/prime/src/cmake-3.28.1/Utilities/cmzlib/gzguts.h:21:
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX15.4.sdk/usr/include/stdio.h:61:
/Library/Developer/CommandLineTools/SDKs/MacOSX15.4.sdk/usr/include/_stdio.h:318:7: error: expected ')'
  318 | FILE    *fdopen(int, const char *) __DARWIN_ALIAS_STARTING(__MAC_10_6, __IPHONE_2_0, __DARWIN_ALIAS(fdopen));
      |          ^
/Users/tingweilin/devenv/flavors/prime/src/cmake-3.28.1/Utilities/cmzlib/zutil.h:147:33: note: expanded from macro 'fdopen'
  147 | #        define fdopen(fd,mode) NULL /* No fdopen() */
      |                                 ^
/Library/Developer/CommandLineTools/usr/lib/clang/17/include/__stddef_null.h:26:22: note: expanded from macro 'NULL'
   26 | #define NULL ((void*)0)
      |                      ^
/Library/Developer/CommandLineTools/SDKs/MacOSX15.4.sdk/usr/include/_stdio.h:318:7: note: to match this '('
/Users/tingweilin/devenv/flavors/prime/src/cmake-3.28.1/Utilities/cmzlib/zutil.h:147:33: note: expanded from macro 'fdopen'
  147 | #        define fdopen(fd,mode) NULL /* No fdopen() */
      |                                 ^
/Library/Developer/CommandLineTools/usr/lib/clang/17/include/__stddef_null.h:26:14: note: expanded from macro 'NULL'
   26 | #define NULL ((void*)0)
      |              ^
3 errors generated.
make[2]: *** [Utilities/cmzlib/CMakeFiles/cmzlib.dir/zutil.c.o] Error 1
make[1]: *** [Utilities/cmzlib/CMakeFiles/cmzlib.dir/all] Error 2
make: *** [all] Error 2
```

# Fix

A fix was made by changing the build version to 4.0.1 (lastest version), and has been confirmed by me that CMake and modmesh pilot can be built successfully after this change.

**Test Configuration**
* macOS Sequoia Version 15.3.2
* Python 3.13.2 (built with devenv)
* Apple clang version 17.0.0 (clang-1700.0.13.3)
    * Target: arm64-apple-darwin24.3.0
    * Thread model: posix

# Test Steps

```bash
devenv build cmake
```