### PR TITLE
Update Qt and PySide to 6.9.2 for macos26 (Tahoe)

### DIFF
--- a/scripts/build.d/pyside6
+++ b/scripts/build.d/pyside6
@@ -28,7 +28,7 @@ elif [ "${SRCSYNC}" == "git" ] ; then
 
   # PySide repository: https://code.qt.io/cgit/pyside/pyside-setup.git/
   pkgname=pyside-setup
-  pkgbranch=${VERSION:-v6.8.1}
+  pkgbranch=${VERSION:-v6.9.2}
   pkgfull=$pkgname
 
   # unpack (clone)
@@ -114,8 +114,10 @@ EOF
   install_cmd+=("install")
 
   install_cmd+=("--qtpaths=${QTPATHS}")
+  install_cmd+=("--verbose-build")
   install_cmd+=("--ignore-git")
   install_cmd+=("--no-qt-tools")
+  install_cmd+=("--enable-numpy-support")
   install_cmd+=("--parallel=${NP}")
   if [ "${PYSIDE_REUSE_BUILD}" == "1" ] ; then
     install_cmd+=("--reuse-build")

--- a/scripts/build.d/qt
+++ b/scripts/build.d/qt
@@ -17,10 +17,10 @@ SKIPEXTRACT=${SKIPEXTRACT:-0}
 
 if [ -z "${SYNCGIT}" ]; then
   pkgname=qt
-  pkgmajorver=${MAJOR_VER:-6.8}
-  pkgsubver=${SUB_VER:-1}
+  pkgmajorver=${MAJOR_VER:-6.9}
+  pkgsubver=${SUB_VER:-2}
   pkgver=$pkgmajorver.$pkgsubver
-  pkgmd5=${MD5:-4068b07ca6366bcb9ba56508bbbf20e6}
+  pkgmd5=${MD5:-78fe69ae8049f6b0139ceaa28e643f53}
   pkgfull=$pkgname-$pkgver
   pkgfoler=qt-everywhere-src-$pkgver
 
@@ -42,7 +42,7 @@ if [ -z "${SYNCGIT}" ]; then
   fi
 else
   pkgname=qt
-  pkgbranch=${VERSION:-6.8.1}
+  pkgbranch=${VERSION:-6.9.2}
   pkgfull=$pkgname-$pkgbranch
   # qt5 is expected here, it seems qt did not change its repository name from qt5 to qt6
   # ref : https://wiki.qt.io/Building_Qt_6_from_Git#Getting_the_source_code

--- a/scripts/func.d/build_utils
+++ b/scripts/func.d/build_utils
@@ -44,6 +44,7 @@ syncgit () {
     git clone -b ${pkgbranch} ${pkgrepo} ${pkgfull}
   else
     pushd ${pkgfull}
+    git fetch
     git checkout ${pkgbranch}
     git pull origin ${pkgbranch}
     popd > /dev/null


### PR DESCRIPTION
Macos26 (Tahoe) requires Qt version 6.9.2: https://bugreports.qt.io/browse/QTBUG-137687