### PR TITLE
feat: Fix zsh compatibility in init script

### DIFF
--- a/scripts/init
+++ b/scripts/init
@@ -1,4 +1,14 @@
-export DEVENVROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# zsh/bash compatible version
+if [ -n "$ZSH_VERSION" ]; then
+    # zsh
+    export DEVENVROOT="$(cd "$(dirname "${(%):-%x}")/.." && pwd)"
+elif [ -n "$BASH_VERSION" ]; then
+    # bash
+    export DEVENVROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+else
+    # fallback
+    export DEVENVROOT="$(cd "$(dirname "$0")/.." && pwd)"
+fi
 
 . ${DEVENVROOT}/scripts/env.d/vars
 


### PR DESCRIPTION
## Problem

The current scripts/init script fails when tried in zsh because BASH_SOURCE[0] is empty in zsh, causing the DEVENVROOT path detection to fail.

## Error 
```
scripts/init:.:3: no such file or directory: /Users/username/scripts/env.d/vars
```
## Reason
```
+scripts/init:1> dirname ''           # BASH_SOURCE[0] is empty in zsh
+scripts/init:1> cd ./..              # Goes to parent of current dir, not script dir  
+scripts/init:1> export DEVENVROOT=/Users/username  # Wrong path!
```
- Enables devenv usage for zsh users (common on macOS)

## Testing
```
# in zsh
source scripts/init
echo "DEVENVROOT: $DEVENVROOT"
devenv

# in bash
bash -c "cd ~/devenv && source scripts/init && echo 'DEVENVROOT: $DEVENVROOT'"
```

[x] Tested on macOS with zsh 5.x
[x] Tested backward compatibility with bash
[x] Verified devenv functionality works after change its ok👌 

## What I didnt do
- Test the fallback case in the code