### PR TITLE
Upgrade Ubuntu CI runner from ubuntu-20.04 to ubuntu-22.04

### DIFF
--- a/.github/workflows/build_pkg_runner.yml
+++ b/.github/workflows/build_pkg_runner.yml
@@ -7,11 +7,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
         matrix:
-          os: [ubuntu-20.04, macos-latest]
+          os: [ubuntu-22.04, macos-latest]
         fail-fast: false
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         fetch-depth: 1
     - name: Scotch - tarball build

--- a/.github/workflows/build_pkg_runner.yml
+++ b/.github/workflows/build_pkg_runner.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
         matrix:
-          os: [ubuntu-22.04, macos-latest]
+          os: [ubuntu-24.04, macos-latest]
         fail-fast: false
     steps:
     - name: Checkout Repository

--- a/.github/workflows/shunit2_runner.yml
+++ b/.github/workflows/shunit2_runner.yml
@@ -7,11 +7,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-15]
+        os: [ubuntu-22.04, macos-15]
       fail-fast: false
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Checkout submodules
         run: git submodule update --init --recursive
       - name: Unittest

--- a/.github/workflows/shunit2_runner.yml
+++ b/.github/workflows/shunit2_runner.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-15]
+        os: [ubuntu-24.04, macos-15]
       fail-fast: false
     steps:
       - name: Checkout repository

--- a/.github/workflows/solvcon_runner.yml
+++ b/.github/workflows/solvcon_runner.yml
@@ -7,11 +7,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
         matrix:
-          os: [ubuntu-20.04, macos-latest]
+          os: [ubuntu-22.04, macos-latest]
         fail-fast: false
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         fetch-depth: 1
     - name: Set DEVENV_WORKSPACE

--- a/.github/workflows/solvcon_runner.yml
+++ b/.github/workflows/solvcon_runner.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
         matrix:
-          os: [ubuntu-22.04, macos-latest]
+          os: [ubuntu-24.04, macos-latest]
         fail-fast: false
     steps:
     - name: Checkout Repository


### PR DESCRIPTION
This PR fixes issue #175 by upgrading the deprecated Ubuntu CI runner version.

## Changes Made
- Updated all GitHub Actions workflows to use ubuntu-22.04 instead of deprecated ubuntu-20.04
- Upgraded actions/checkout from v2 to v4 for better security and features

## Files Updated
- .github/workflows/build_pkg_runner.yml
- .github/workflows/shunit2_runner.yml  
- .github/workflows/solvcon_runner.yml

## Why This Change Is Needed
The current runner version uses Ubuntu 20.04 which has been deprecated by GitHub Actions and causes CI jobs to fail. Ubuntu 22.04 is the current LTS version and is fully supported by GitHub Actions.

Fixes #175