### PR TITLE
ci: Fix dependencies for Application Build - SOLVCON

### DIFF
--- a/.github/workflows/solvcon_runner.yml
+++ b/.github/workflows/solvcon_runner.yml
@@ -24,6 +24,28 @@ jobs:
       if: matrix.os != 'macos-latest'
       run: |
         source ${DEVENV_WORKSPACE}/contrib/ci-setup-apt.sh
+    - name: Cache Homebrew downloads (macOS)
+      if: matrix.os == 'macos-latest'
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/Library/Caches/Homebrew
+          /usr/local/Homebrew
+        key: brew-${{ runner.os }}
+        restore-keys: |
+          brew-${{ runner.os }}-
+    - name: Dependency (macOS)
+      if: matrix.os == 'macos-latest'
+      run: |
+        brew update --quiet
+        brew install --cask mactex-no-gui
+        TEXBIN="/Library/TeX/texbin"
+        echo "PATH=${TEXBIN}:$PATH" >> $GITHUB_ENV
+        if [[ "$(uname -m)" == "arm64" ]]; then
+          echo "PYTHON_DECIMAL_WITH_MACHINE=uint128" >> $GITHUB_ENV
+        else
+          echo "PYTHON_DECIMAL_WITH_MACHINE=x64" >> $GITHUB_ENV
+        fi
     - name: Launch SOLVCON
       run: |
         source ${DEVENV_WORKSPACE}/scripts/init

--- a/applications/solvcon/entry.sh
+++ b/applications/solvcon/entry.sh
@@ -34,21 +34,35 @@ devenv build bzip2
 #     error: System version of SQLite does not support loadable extensions
 #     make: *** [sharedmods] Error 1
 devenv build sqlite
-VERSION=3.8 devenv build python
-devenv build cmake
+# pip>=25 requires virtualenv;
+#     disable via PIP_REQUIRE_VIRTUALENV=false
+export PIP_REQUIRE_VIRTUALENV=false
+VERSION=3.8.20 devenv build python
+VERSION=3.31.9 devenv build cmake
 # scotch will be used later by libmarch
 # cmake will be used for building scotch
 devenv build scotch
 
 # prepare all packages to build SOLVCON
+pip3 install "setuptools<60.0" wheel
 pip3 install nose boto paramiko netCDF4
+pip3 install sphinx furo Pillow
 pip3 install numpy==1.21.4
-devenv build pybind11
-devenv build gmsh
+VERSION=2.11.2 devenv build pybind11
+
 devenv build hdf
 
+if [[ "$(uname)" == "Darwin" ]]; then
+  CMAKE_C_FLAGS="-include unistd.h -include string.h" \
+  CFLAGS="-include unistd.h -include string.h" \
+  devenv build gmsh
+else
+  devenv build gmsh
+fi
+
+
 python_exe_base=$(which python3)
-PYTHON_EXE=${python_exe_base} devenv build cython
+VERSION=0.29.37 PYTHON_EXE=${python_exe_base} devenv build cython
 
 pushd ${SCSRC}
 # make libmarch.so and SOLVCON

--- a/contrib/ci-setup-apt.sh
+++ b/contrib/ci-setup-apt.sh
@@ -4,3 +4,7 @@ sudo apt-get -qqy install \
         fakeroot debhelper locales \
         libffi-dev \
         liblapack3 liblapack-dev
+
+# for sphinx's latex engine
+sudo apt-get install -qqy texlive-latex-base texlive-latex-recommended latexmk
+sudo apt-get install -qqy ghostscript imagemagick

--- a/scripts/build.d/cython
+++ b/scripts/build.d/cython
@@ -7,7 +7,7 @@ SRCSYNC=${SRCSYNC:-tarball}
 if [ "${SRCSYNC}" == "tarball" ] ; then
 
   # Tarball location: https://github.com/cython/cython/releases
-  pkgname=Cython
+  pkgname=cython
   pkgver=${VERSION:-3.0.12}
   pkgfull=${pkgname}-${pkgver}
   pkgfn=${pkgfull}.tar.gz

--- a/scripts/build.d/python
+++ b/scripts/build.d/python
@@ -73,7 +73,6 @@ pushd ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src/${pkgfull} > /dev/null
   cfgcmd+=("--enable-optimizations")
   cfgcmd+=("--without-ensurepip")
   cfgcmd+=("--with-system-expat")
-  cfgcmd+=("--with-system-ffi")
   cfgcmd+=("--with-system-libmpdec")
   cfgcmd+=("--with-readline=editline")
   cfgcmd+=("--with-lto")
@@ -82,6 +81,8 @@ pushd ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src/${pkgfull} > /dev/null
   if [[ $(uname) == Darwin ]] ; then
     cfgcmd+=("--with-dtrace")
     cfgcmd+=("--with-dbmliborder=ndbm")
+  elif [ $(uname) == Linux ]; then
+    cfgcmd+=("--with-system-ffi")
   fi
 
   # Some Python extension does not work properly without this, e.g., pandas.

--- a/scripts/build.d/python
+++ b/scripts/build.d/python
@@ -104,11 +104,16 @@ pushd ${DEVENVFLAVORROOT}/${DEVENVFLAVOR}/src/${pkgfull} > /dev/null
   PY_BIN=${PREFIX}/bin/python3
   CURL_URL=https://bootstrap.pypa.io/get-pip.py
 
-  IFS='.' read -ra VER <<< ${VERSION}
+  IFS='.' read -ra VER <<< "${VERSION}"
 
-  if [[ ${VER[0]} == "v2" ]]; then
+  if [[ "${VER[0]}" == "v2" || "${VER[0]}" == "2" ]]; then
     PY_BIN=${PREFIX}/bin/python
     CURL_URL=https://bootstrap.pypa.io/pip/2.7/get-pip.py
+  elif (( "${VER[0]}" == 3 && "${VER[1]}" < 6 )); then
+    echo "ERROR: Python ${pkgver} is below 3.6. get-pip is not supported."
+    exit 1
+  elif (( "${VER[0]}" == 3 && "${VER[1]}" < 9 )); then
+    CURL_URL="https://bootstrap.pypa.io/pip/${VER[0]}.${VER[1]}/get-pip.py"
   fi
 
   curl ${CURL_URL} | ${PY_BIN}


### PR DESCRIPTION
This PR updates the SOLVCON build CI workflows with improved dependency setup, Python build configuration, and cross-platform (macOS/Ubuntu) support:

#### Add new dependencies for SOLVCON documentation
- Add Sphinx-related packages and LaTeX/image processing tools required for building documentation (make -C doc html) on both macOS and Ubuntu runners.
- On macOS, use `mactex-no-gui` for a lightweight LaTeX installation and add a cache stage for Homebrew to speed up future CI runs (note: caching takes effect only after a first successful pipeline).

#### Set compatible versions for core build dependencies
- Pin setuptools, numpy, pybind11, and cython to mutually compatible versions to stabilize build results.  
- Pin CMake to `3.x` to avoid breaking changes in the upcoming `4.x` series.  
- Use Python `3.8.20` as the default version for reproducible builds.
- On macOS, explicitly add CFLAGS `-include string.h` and `-include unistd.h` when compiling gmsh to handle stricter header requirements in newer Clang versions, caused by missing standard includes in the legacy **concorde97** sources bundled with gmsh.

#### Improve Python build script (`scripts/build.d/python`)
- Extend `get-pip.py` support to Python from `3.6` to `current`, refining logic for selecting version-specific URLs and providing clearer error messages for unsupported versions.  
- Apply `--with-system-ffi` only for Linux builds, since macOS support for system ffi becomes stable only after Python `3.9.x`.

The CI workflow has been improved but **still fails** under certain stage:  
- A build issue occurs when compiling `libmarch` on arm64 macOS due to a lack of x86 SIMD (SSE) headers.  
- On the Ubuntu runner, the SOLVCON function test stage reports missing `_algorithm` runtime errors; the root cause has not yet been investigated.

CI logs for reference: GitHub Actions run [#18260545494](https://github.com/terrychan999/devenv/actions/runs/18260545494).